### PR TITLE
[Feat] #44. Board, Post, Commnet의 delete 기능에 로깅 기능 추가

### DIFF
--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
@@ -7,11 +7,13 @@ import com.kernel360.orury.domain.board.model.BoardRequest;
 
 import lombok.RequiredArgsConstructor;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BoardService {
@@ -62,6 +64,7 @@ public class BoardService {
 
 	public void deleteBoard(Long id) {
 		boardRepository.deleteById(id);
+		log.info("게시판이 삭제되었습니다. : {}", id);
 	}
 
 	public BoardDto getBoard(Long id) {

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/comment/service/CommentService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/comment/service/CommentService.java
@@ -8,6 +8,7 @@ import com.kernel360.orury.domain.comment.model.CommentRequest;
 import com.kernel360.orury.domain.post.db.PostEntity;
 import com.kernel360.orury.domain.post.db.PostRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -21,6 +22,7 @@ import java.util.Optional;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CommentService {
     private final CommentRepository commentRepository;
     private final CommentConverter commentConverter;
@@ -67,6 +69,7 @@ public class CommentService {
             CommentDelRequest commentDelRequest
     ){
         commentRepository.deleteById(commentDelRequest.getId());
+        log.info("댓글이 삭제되었습니다. : {}",commentDelRequest.getId());
     }
 
     public List<CommentDto> findAllByPostId(Long postId) {

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostService.java
@@ -10,12 +10,14 @@ import com.kernel360.orury.domain.post.model.PostRequest;
 
 import lombok.RequiredArgsConstructor;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class PostService {
@@ -74,6 +76,7 @@ public class PostService {
 		Long id
 	) {
 		postRepository.deleteById(id);
+		log.info("게시글이 삭제되었습니다. : {}", id);
 	}
 
 	public List<PostDto> getPostList() {

--- a/backend/orury/src/main/resources/logback.xml
+++ b/backend/orury/src/main/resources/logback.xml
@@ -1,0 +1,38 @@
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) [%C.%M:%line] - %msg%n</Pattern>
+        </layout>
+    </appender>
+
+    <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- Rolling 정책 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOCAL_LOG_URL}/logs/logback-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <!-- 1일까지 보관 -->
+            <maxHistory>1</maxHistory>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <!-- or whenever the file size reaches 1KB -->
+                <maxFileSize>1KB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+
+    </appender>
+
+
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="com.kernel360.orury.domain" level="INFO">
+        <appender-ref ref="ROLLING" />
+    </logger>
+
+
+</configuration>


### PR DESCRIPTION
- 각 service 파일의 delete 메서드 안에 log 코드를 넣었습니다.
- log는 환경변수 LOCAL_LOG_URL 위치의 logs 폴더에 쌓입니다.
- 지금은 로그 정책을 임의로 설정한 상태이고 이후에 로그 정책을 정해야할 필요성이 있습니다.