### PR TITLE
[Feat] #60. 로깅 로직 개선

### DIFF
--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/db/BoardEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/db/BoardEntity.java
@@ -2,6 +2,7 @@ package com.kernel360.orury.domain.board.db;
 
 import com.kernel360.orury.domain.post.db.PostEntity;
 import com.kernel360.orury.global.domain.BaseEntity;
+import com.kernel360.orury.global.domain.Listener;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.OrderBy;
@@ -17,6 +18,7 @@ import java.util.List;
  */
 @ToString
 @Entity(name = "board")
+@EntityListeners(Listener.class)
 @Getter
 @SuperBuilder
 @NoArgsConstructor

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
@@ -4,16 +4,12 @@ import com.kernel360.orury.domain.board.db.BoardEntity;
 import com.kernel360.orury.domain.board.db.BoardRepository;
 import com.kernel360.orury.domain.board.model.BoardDto;
 import com.kernel360.orury.domain.board.model.BoardRequest;
-
 import lombok.RequiredArgsConstructor;
-
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BoardService {
@@ -64,7 +60,6 @@ public class BoardService {
 
 	public void deleteBoard(Long id) {
 		boardRepository.deleteById(id);
-		log.info("게시판이 삭제되었습니다. : {}", id);
 	}
 
 	public BoardDto getBoard(Long id) {

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/comment/db/CommentEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/comment/db/CommentEntity.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.kernel360.orury.domain.post.db.PostEntity;
 import com.kernel360.orury.global.domain.BaseEntity;
+import com.kernel360.orury.global.domain.Listener;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +20,7 @@ import javax.persistence.*;
  * description : 댓글 엔티티
  */
 @Entity(name = "comment")
+@EntityListeners(Listener.class)
 @Getter
 @SuperBuilder
 @ToString

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/comment/service/CommentService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/comment/service/CommentService.java
@@ -8,7 +8,6 @@ import com.kernel360.orury.domain.comment.model.CommentRequest;
 import com.kernel360.orury.domain.post.db.PostEntity;
 import com.kernel360.orury.domain.post.db.PostRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -22,7 +21,6 @@ import java.util.Optional;
  */
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class CommentService {
     private final CommentRepository commentRepository;
     private final CommentConverter commentConverter;
@@ -69,7 +67,6 @@ public class CommentService {
             CommentDelRequest commentDelRequest
     ){
         commentRepository.deleteById(commentDelRequest.getId());
-        log.info("댓글이 삭제되었습니다. : {}",commentDelRequest.getId());
     }
 
     public List<CommentDto> findAllByPostId(Long postId) {

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostEntity.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kernel360.orury.domain.board.db.BoardEntity;
 import com.kernel360.orury.domain.comment.db.CommentEntity;
 import com.kernel360.orury.global.domain.BaseEntity;
+import com.kernel360.orury.global.domain.Listener;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.OrderBy;
@@ -17,6 +18,7 @@ import java.util.List;
 @ToString
 @SuperBuilder
 @Entity(name = "post")
+@EntityListeners(Listener.class)
 public class PostEntity extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostImageEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostImageEntity.java
@@ -3,6 +3,7 @@ package com.kernel360.orury.domain.post.db;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kernel360.orury.global.domain.BaseEntity;
 import com.kernel360.orury.domain.post.db.PostEntity;
+import com.kernel360.orury.global.domain.Listener;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,7 @@ import javax.persistence.*;
 @ToString
 @SuperBuilder
 @Entity(name = "post_image")
+@EntityListeners(Listener.class)
 public class PostImageEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostService.java
@@ -2,28 +2,22 @@ package com.kernel360.orury.domain.post.service;
 
 import com.kernel360.orury.domain.board.db.BoardRepository;
 import com.kernel360.orury.domain.comment.service.CommentService;
+import com.kernel360.orury.domain.post.db.PostEntity;
 import com.kernel360.orury.domain.post.db.PostImageEntity;
 import com.kernel360.orury.domain.post.db.PostImageRepository;
-import com.kernel360.orury.domain.post.model.PostViewRequest;
-import com.kernel360.orury.domain.post.db.PostEntity;
 import com.kernel360.orury.domain.post.db.PostRepository;
 import com.kernel360.orury.domain.post.model.PostDto;
 import com.kernel360.orury.domain.post.model.PostRequest;
-
 import com.kernel360.orury.global.domain.Api;
 import com.kernel360.orury.global.domain.Pagination;
 import lombok.RequiredArgsConstructor;
-
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
-@Slf4j
 @RequiredArgsConstructor
 @Service
 public class PostService {
@@ -107,7 +101,6 @@ public class PostService {
 		Long id
 	) {
 		postRepository.deleteById(id);
-		log.info("게시글이 삭제되었습니다. : {}", id);
 	}
 
 	public Api<List<PostDto>> getPostList(Pageable pageable) {

--- a/backend/orury/src/main/java/com/kernel360/orury/global/domain/Listener.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/global/domain/Listener.java
@@ -1,0 +1,15 @@
+package com.kernel360.orury.global.domain;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.persistence.PostRemove;
+
+
+@Slf4j
+public class Listener {
+
+    @PostRemove
+    public void preRemove(Object entity) {
+        log.info("삭제되었습니다. : {}", entity.toString());
+    }
+}

--- a/backend/orury/src/main/resources/application.yml
+++ b/backend/orury/src/main/resources/application.yml
@@ -14,10 +14,3 @@ spring:
     url: ${LOCAL_DB_URL} # configuration에서 설정 필요
     username: ${LOCAL_DB_USERNAME}
     password: ${LOCAL_DB_USER_PASSWORD}
-logging:
-  level:
-    org:
-      hibernate:
-        type:
-          descriptor:
-            sql: trace

--- a/backend/orury/src/main/resources/logback.xml
+++ b/backend/orury/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
             <maxHistory>1</maxHistory>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <!-- or whenever the file size reaches 1KB -->
-                <maxFileSize>1KB</maxFileSize>
+                <maxFileSize>2MB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
 
@@ -30,7 +30,15 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-    <logger name="com.kernel360.orury.domain" level="INFO">
+    <logger name="com.kernel360.orury.global" level="INFO">
+        <appender-ref ref="ROLLING" />
+    </logger>
+
+    <logger name="org.hibernate.type.descriptor.sql" level="TRACE">
+        <appender-ref ref="ROLLING" />
+    </logger>
+
+    <logger name="org.hibernate.SQL" level="DEBUG">
         <appender-ref ref="ROLLING" />
     </logger>
 


### PR DESCRIPTION
- oncascade로 하위 엔티티까지 지워질 때 지워진 하위 엔티티에 대한 정보도 로그로 남게 기존 로깅 로직 대신 Event Listener 기능을 사용하여 로직 수정
- 실행한 동작에 대한 sql 구문과 변수 ?에 대한 정보를 추가로 로그를 남기게 함
- 로그 파일의 최대 크기를 1KB -> 2MB로 변경