### PR TITLE
[Feat] Kernel360#58. 메시지 및 상수 enum 처리 

### DIFF
--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/db/BoardEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/db/BoardEntity.java
@@ -1,11 +1,10 @@
 package com.kernel360.orury.domain.board.db;
 
 import com.kernel360.orury.domain.post.db.PostEntity;
-import com.kernel360.orury.global.domain.BaseEntity;
+import com.kernel360.orury.global.common.BaseEntity;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.OrderBy;
-import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.List;

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
@@ -5,6 +5,9 @@ import com.kernel360.orury.domain.board.db.BoardRepository;
 import com.kernel360.orury.domain.board.model.BoardDto;
 import com.kernel360.orury.domain.board.model.BoardRequest;
 
+import com.kernel360.orury.global.constants.Constant;
+import com.kernel360.orury.global.message.errors.ErrorMessages;
+import com.kernel360.orury.global.message.info.InfoMessages;
 import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;
@@ -26,9 +29,9 @@ public class BoardService {
 	) {
 		var entity = BoardEntity.builder()
 			.boardTitle(boardRequest.getBoardTitle())
-			.createdBy("admin")  // 임의로 "admin" 넣음
+			.createdBy(Constant.ADMIN.getMessage())
 			.createdAt(LocalDateTime.now())
-			.updatedBy("admin") // 임의로 "admin" 넣음
+			.updatedBy(Constant.ADMIN.getMessage())
 			.updatedAt(LocalDateTime.now())
 			.build();
 
@@ -50,11 +53,11 @@ public class BoardService {
 		BoardRequest boardRequest
 	) {
 		BoardEntity entity = boardRepository.findById(boardRequest.getId())
-			.orElseThrow(() -> new RuntimeException("해당 게시판이 존재하지 않습니다: " + boardRequest.getId()));
+			.orElseThrow(() -> new RuntimeException(ErrorMessages.THERE_IS_NO_BOARD.getMessage() + boardRequest.getId()));
 
 		BoardDto updatedDto = boardConverter.toDto(entity);
 		updatedDto.setBoardTitle(boardRequest.getBoardTitle());
-		updatedDto.setUpdatedBy("admin"); // 임의로 "admin" 넣음
+		updatedDto.setUpdatedBy(Constant.ADMIN.getMessage());
 		updatedDto.setUpdatedAt(LocalDateTime.now());
 
 		boardRepository.save(boardConverter.toEntity(updatedDto));
@@ -64,12 +67,12 @@ public class BoardService {
 
 	public void deleteBoard(Long id) {
 		boardRepository.deleteById(id);
-		log.info("게시판이 삭제되었습니다. : {}", id);
+		log.info(InfoMessages.BOARD_DELETED.getMessage() + id);
 	}
 
 	public BoardDto getBoard(Long id) {
 		var entity = boardRepository.findById(id)
-			.orElseThrow(() -> new RuntimeException("게시판이 존재하지 않습니다.: " + id));
+			.orElseThrow(() -> new RuntimeException(ErrorMessages.THERE_IS_NO_BOARD.getMessage() + id));
 
 		return boardConverter.toDto(entity);
 	}

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/comment/db/CommentEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/comment/db/CommentEntity.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.kernel360.orury.domain.post.db.PostEntity;
-import com.kernel360.orury.global.domain.BaseEntity;
+import com.kernel360.orury.global.common.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/comment/service/CommentConverter.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/comment/service/CommentConverter.java
@@ -4,6 +4,7 @@ import com.kernel360.orury.domain.comment.db.CommentEntity;
 import com.kernel360.orury.domain.comment.model.CommentDto;
 import com.kernel360.orury.domain.post.db.PostEntity;
 import com.kernel360.orury.domain.post.db.PostRepository;
+import com.kernel360.orury.global.message.errors.ErrorMessages;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -31,7 +32,7 @@ public class CommentConverter {
     public CommentEntity toEntity(CommentDto commentdto) {
         PostEntity postEntity = postRepository.findById(commentdto.getPostId())
                 .orElseThrow(
-                        () -> new RuntimeException("해당 게시글이 없습니다: " + commentdto.getPostId())
+                        () -> new RuntimeException(ErrorMessages.THERE_IS_NO_POST.getMessage() + commentdto.getPostId())
                 );
         return CommentEntity.builder()
                 .id(commentdto.getId())

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/comment/service/CommentService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/comment/service/CommentService.java
@@ -7,6 +7,9 @@ import com.kernel360.orury.domain.comment.model.CommentDto;
 import com.kernel360.orury.domain.comment.model.CommentRequest;
 import com.kernel360.orury.domain.post.db.PostEntity;
 import com.kernel360.orury.domain.post.db.PostRepository;
+import com.kernel360.orury.global.constants.Constant;
+import com.kernel360.orury.global.message.errors.ErrorMessages;
+import com.kernel360.orury.global.message.info.InfoMessages;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -38,9 +41,9 @@ public class CommentService {
                 .userNickname(commentRequest.getUserNickname())
                 // 대댓글과 본댓글 판별
                 .pId(commentRequest.getId() == null ? null : commentRequest.getId())
-                .createdBy("admin")
+                .createdBy(Constant.ADMIN.getMessage())
                 .createdAt(LocalDateTime.now())
-                .updatedBy("admin")
+                .updatedBy(Constant.ADMIN.getMessage())
                 .updatedAt(LocalDateTime.now())
                 .build();
 
@@ -54,10 +57,10 @@ public class CommentService {
     ){
         Long id = commentRequest.getId();
         Optional<CommentEntity> entity = commentRepository.findById(id);
-        CommentEntity updateEntity = entity.orElseThrow(() -> new RuntimeException("해당 댓글이 없습니다." + id));
+        CommentEntity updateEntity = entity.orElseThrow(() -> new RuntimeException(ErrorMessages.THERE_IS_NO_COMMENT.getMessage() + id));
         CommentDto updateDto = commentConverter.toDto(updateEntity);
         updateDto.setCommentContent(commentRequest.getCommentContent());
-        updateDto.setUpdatedBy("admin");
+        updateDto.setUpdatedBy(Constant.ADMIN.getMessage());
         updateDto.setUpdatedAt(LocalDateTime.now());
         CommentEntity saveEntity = commentConverter.toEntity(updateDto);
         commentRepository.save(saveEntity);
@@ -69,7 +72,7 @@ public class CommentService {
             CommentDelRequest commentDelRequest
     ){
         commentRepository.deleteById(commentDelRequest.getId());
-        log.info("댓글이 삭제되었습니다. : {}",commentDelRequest.getId());
+        log.info(InfoMessages.COMMENT_DELETED.getMessage() + commentDelRequest.getId());
     }
 
     public List<CommentDto> findAllByPostId(Long postId) {

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/controller/PostController.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/controller/PostController.java
@@ -4,7 +4,7 @@ import com.kernel360.orury.domain.post.model.PostDto;
 import com.kernel360.orury.domain.post.model.PostRequest;
 import com.kernel360.orury.domain.post.service.PostService;
 
-import com.kernel360.orury.global.domain.Api;
+import com.kernel360.orury.global.common.Api;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Pageable;

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostEntity.java
@@ -3,7 +3,7 @@ package com.kernel360.orury.domain.post.db;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kernel360.orury.domain.board.db.BoardEntity;
 import com.kernel360.orury.domain.comment.db.CommentEntity;
-import com.kernel360.orury.global.domain.BaseEntity;
+import com.kernel360.orury.global.common.BaseEntity;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.OrderBy;

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostImageEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostImageEntity.java
@@ -1,8 +1,7 @@
 package com.kernel360.orury.domain.post.db;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.kernel360.orury.global.domain.BaseEntity;
-import com.kernel360.orury.domain.post.db.PostEntity;
+import com.kernel360.orury.global.common.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostConverter.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostConverter.java
@@ -5,6 +5,7 @@ import com.kernel360.orury.domain.board.db.BoardRepository;
 import com.kernel360.orury.domain.comment.service.CommentConverter;
 import com.kernel360.orury.domain.post.db.PostEntity;
 import com.kernel360.orury.domain.post.model.PostDto;
+import com.kernel360.orury.global.message.errors.ErrorMessages;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -44,7 +45,7 @@ public class PostConverter {
     public PostEntity toEntity(PostDto postDto) {
         BoardEntity boardEntity = boardRepository.findById(postDto.getBoardId())
                 .orElseThrow(
-                        () -> new RuntimeException("해당 게시판이 없습니다: " + postDto.getBoardId())
+                        () -> new RuntimeException(ErrorMessages.THERE_IS_NO_BOARD.getMessage() + postDto.getBoardId())
                 );
 
         return PostEntity.builder()

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostService.java
@@ -4,14 +4,16 @@ import com.kernel360.orury.domain.board.db.BoardRepository;
 import com.kernel360.orury.domain.comment.service.CommentService;
 import com.kernel360.orury.domain.post.db.PostImageEntity;
 import com.kernel360.orury.domain.post.db.PostImageRepository;
-import com.kernel360.orury.domain.post.model.PostViewRequest;
 import com.kernel360.orury.domain.post.db.PostEntity;
 import com.kernel360.orury.domain.post.db.PostRepository;
 import com.kernel360.orury.domain.post.model.PostDto;
 import com.kernel360.orury.domain.post.model.PostRequest;
 
-import com.kernel360.orury.global.domain.Api;
-import com.kernel360.orury.global.domain.Pagination;
+import com.kernel360.orury.global.common.Api;
+import com.kernel360.orury.global.common.Pagination;
+import com.kernel360.orury.global.constants.Constant;
+import com.kernel360.orury.global.message.errors.ErrorMessages;
+import com.kernel360.orury.global.message.info.InfoMessages;
 import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +23,6 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,17 +31,14 @@ public class PostService {
 	private final PostRepository postRepository;
 	private final BoardRepository boardRepository;
 	private final PostConverter postConverter;
-	private final CommentService commentService;
 	private final PostImageRepository postImageRepository;
-
-	private static final String ADMIN = "admin";
 
 	public PostDto createPost(
 		PostRequest postRequest
 	) {
 
 		var boardEntity = boardRepository.findById(postRequest.getBoardId())
-			.orElseThrow(() -> new RuntimeException("해당 게시판이 없습니다"));
+			.orElseThrow(() -> new RuntimeException(ErrorMessages.THERE_IS_NO_BOARD.getMessage()));
 
 		var entity = PostEntity.builder()
 			.postTitle(postRequest.getPostTitle())
@@ -49,9 +47,9 @@ public class PostService {
 			.userId(postRequest.getUserId())
 			.board(boardEntity)
 			.thumbnailUrl(postRequest.getPostImageList().isEmpty() ? null : postRequest.getPostImageList().get(0))
-			.createdBy(ADMIN)
+			.createdBy(Constant.ADMIN.getMessage())
 			.createdAt(LocalDateTime.now())
-			.updatedBy(ADMIN)
+			.updatedBy(Constant.ADMIN.getMessage())
 			.updatedAt(LocalDateTime.now())
 			.build();
 		var saveEntity = postRepository.save(entity);
@@ -63,9 +61,9 @@ public class PostService {
 					PostImageEntity postImageEntity = PostImageEntity.builder()
 							.imageUrl(url)
 							.post(entity)
-							.createdBy(ADMIN)
+							.createdBy(Constant.ADMIN.getMessage())
 							.createdAt(LocalDateTime.now())
-							.updatedBy(ADMIN)
+							.updatedBy(Constant.ADMIN.getMessage())
 							.updatedAt(LocalDateTime.now())
 							.build();
 					postImageRepository.save(postImageEntity);
@@ -83,7 +81,7 @@ public class PostService {
 
 	public PostDto getPost(Long id) {
 		Optional<PostEntity> postEntityOptional = postRepository.findById(id);
-		PostEntity post = postEntityOptional.orElseThrow(() -> new RuntimeException("해당 게시글이 존재하지 않습니다: " + id));
+		PostEntity post = postEntityOptional.orElseThrow(() -> new RuntimeException(ErrorMessages.THERE_IS_NO_POST.getMessage() + id));
 		return postConverter.toDto(post);
 	}
 
@@ -92,11 +90,11 @@ public class PostService {
 	) {
 		Long postId = postRequest.getId();
 		var postEntityOptional = postRepository.findById(postId);
-		var entity = postEntityOptional.orElseThrow(() -> new RuntimeException("해당 게시글이 존재하지 않습니다: " + postId));
+		var entity = postEntityOptional.orElseThrow(() -> new RuntimeException(ErrorMessages.THERE_IS_NO_POST.getMessage() + postId));
 		var dto = postConverter.toDto(entity);
 		dto.setPostTitle(postRequest.getPostTitle());
 		dto.setPostContent(postRequest.getPostContent());
-		dto.setUpdatedBy(ADMIN);
+		dto.setUpdatedBy(Constant.ADMIN.getMessage());
 		dto.setUpdatedAt(LocalDateTime.now());
 		var saveEntity = postConverter.toEntity(dto);
 		postRepository.save(saveEntity);
@@ -107,7 +105,7 @@ public class PostService {
 		Long id
 	) {
 		postRepository.deleteById(id);
-		log.info("게시글이 삭제되었습니다. : {}", id);
+		log.info(InfoMessages.POST_DELETED.getMessage() + id);
 	}
 
 	public Api<List<PostDto>> getPostList(Pageable pageable) {

--- a/backend/orury/src/main/java/com/kernel360/orury/global/common/Api.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/global/common/Api.java
@@ -1,4 +1,4 @@
-package com.kernel360.orury.global.domain;
+package com.kernel360.orury.global.common;
 
 
 import lombok.*;

--- a/backend/orury/src/main/java/com/kernel360/orury/global/common/BaseEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/global/common/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.kernel360.orury.global.domain;
+package com.kernel360.orury.global.common;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/orury/src/main/java/com/kernel360/orury/global/common/Pagination.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/global/common/Pagination.java
@@ -1,4 +1,4 @@
-package com.kernel360.orury.global.domain;
+package com.kernel360.orury.global.common;
 
 import lombok.*;
 

--- a/backend/orury/src/main/java/com/kernel360/orury/global/constants/Constant.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/global/constants/Constant.java
@@ -1,0 +1,16 @@
+package com.kernel360.orury.global.constants;
+
+import lombok.Getter;
+
+@Getter
+public enum Constant {
+    ADMIN("admin")
+    ;
+
+    private final String message;
+
+    Constant(String message) {
+        this.message = message;
+    }
+
+}

--- a/backend/orury/src/main/java/com/kernel360/orury/global/message/errors/ErrorMessages.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/global/message/errors/ErrorMessages.java
@@ -1,0 +1,18 @@
+package com.kernel360.orury.global.message.errors;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorMessages {
+    THERE_IS_NO_BOARD("게시판이 존재하지 않습니다."),
+    THERE_IS_NO_POST("게시글이 존재하지 않습니다."),
+    THERE_IS_NO_COMMENT("댓글이 존재하지 않습니다."),
+    ;
+
+    private final String message;
+
+    ErrorMessages(String message) {
+        this.message = message;
+    }
+
+}

--- a/backend/orury/src/main/java/com/kernel360/orury/global/message/info/InfoMessages.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/global/message/info/InfoMessages.java
@@ -1,0 +1,17 @@
+package com.kernel360.orury.global.message.info;
+
+public enum InfoMessages {
+    BOARD_DELETED("게시판이 삭제되었습니다."),
+    POST_DELETED("게시글이 삭제되었습니다."),
+    COMMENT_DELETED("댓글이 삭제되었습니다.");
+
+    private final String message;
+
+    InfoMessages(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
## 개요
Exception 및 정상 처리 시 log값을 표현할 때 하드코딩 된 값을 상수처리 및 메시지로 나눴습니다.
추후 개발 시 하드코딩 대신 global/constants와 global/messages에 값을 추가 후 사용 부탁드립니다.
추가로, global/domain의 이름이 global/common 으로 변경되었습니다.

Resolves: #58 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://quickest-asterisk-75d.notion.site/2a977a0d71db4062bc705dc199ebff13?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
