### PR TITLE
[Refactor] #106 로그인 성공시 유저정보를 프론트엔드에 캐싱하는 작업

### DIFF
--- a/backend/orury/src/main/java/com/kernel360/orury/domain/user/controller/UserController.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/user/controller/UserController.java
@@ -39,7 +39,7 @@ public class UserController {
 		return ResponseEntity.ok(userService.signup(userDto));
 	}
 
-	@GetMapping("/infoㅎ")
+	@GetMapping("/info")
 	@PreAuthorize("hasAnyRole('USER','ADMIN')")
 	public ResponseEntity<UserDto> getMyUserInfo(HttpServletRequest request) {
 		return ResponseEntity.ok(userService.getMyUserWithAuthorities());

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/user/controller/UserController.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/user/controller/UserController.java
@@ -39,7 +39,7 @@ public class UserController {
 		return ResponseEntity.ok(userService.signup(userDto));
 	}
 
-	@GetMapping("/info")
+	@GetMapping("/infoㅎ")
 	@PreAuthorize("hasAnyRole('USER','ADMIN')")
 	public ResponseEntity<UserDto> getMyUserInfo(HttpServletRequest request) {
 		return ResponseEntity.ok(userService.getMyUserWithAuthorities());

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/user/controller/UserController.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/user/controller/UserController.java
@@ -39,7 +39,7 @@ public class UserController {
 		return ResponseEntity.ok(userService.signup(userDto));
 	}
 
-	@GetMapping("/user")
+	@GetMapping("/info")
 	@PreAuthorize("hasAnyRole('USER','ADMIN')")
 	public ResponseEntity<UserDto> getMyUserInfo(HttpServletRequest request) {
 		return ResponseEntity.ok(userService.getMyUserWithAuthorities());

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/user/model/UserDto.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/user/model/UserDto.java
@@ -55,6 +55,7 @@ public class UserDto {
 		return UserDto.builder()
 			.id(user.getId())
 			.emailAddr(user.getEmailAddr())
+			.nickname(user.getNickname())
 			.authorityDtoSet(user.getAuthorities().stream()
 			.map(authority -> AuthorityDto.builder().name(authority.getName()).build())
 			.collect(Collectors.toSet()))

--- a/frontend/lib/global/http/http_request.dart
+++ b/frontend/lib/global/http/http_request.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<http.Response> sendHttpRequest(String method, Uri uri, {String? body, Map<String, String>? headers}) async {
+  SharedPreferences prefs = await SharedPreferences.getInstance();
+  final accessToken = prefs.getString('accessToken');
+  headers = headers ?? {};
+  headers.addAll({
+    "Content-Type": "application/json",
+    'Authorization': 'Bearer $accessToken',
+  });
+
+  http.Response response;
+  switch (method) {
+    case 'GET':
+      response = await http.get(uri, headers: headers);
+      break;
+    case 'POST':
+      response = await http.post(uri, headers: headers, body: body);
+      break;
+    case 'DELETE':
+      response = await http.delete(uri, headers: headers);
+      break;
+    case 'PATCH':
+      response = await http.patch(uri, headers: headers, body: body);
+      break;
+    default:
+      throw Exception('Unsupported HTTP method: $method');
+  }
+
+  if (response.statusCode == 205) {  // 임시 statusCode.
+    final refreshToken = prefs.getString('refreshToken');
+    final tokenResponse = await http.post(
+      Uri.http(dotenv.env['API_URL']!, '/api/auth/refreshToken'),
+      headers: {
+        "Content-Type": "application/json",
+        'Authorization': 'Bearer $accessToken',
+        'Refresh-Token': '$refreshToken',
+      },
+    );
+
+    if (tokenResponse.statusCode == 200) {
+      String newAccessToken = response.headers['newAccessToken'] ?? '';  // 임시 key.
+      await prefs.setString("accessToken", newAccessToken);
+
+      // 재귀 호출하여 새로운 토큰으로 다시 HTTP 요청을 보냅니다.
+      return sendHttpRequest(method, uri, body: body, headers: headers);
+
+    } else {
+      throw Exception('Failed to get newAccessToken');
+    }
+  } else if (response.statusCode != 200) { // 추가적인 예외 처리 필요할 수 도
+    throw Exception('HTTP request failed with status code: ${response.statusCode}');
+  }
+
+  return response;
+}

--- a/frontend/lib/presentation/Board/post_create.dart
+++ b/frontend/lib/presentation/Board/post_create.dart
@@ -10,6 +10,7 @@ import 'package:orury/global/messages/board/post_message.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:orury/presentation/Board/post.dart';
 
+import '../../global/http/http_request.dart';
 import '../routes/routes.dart';
 
 class PostCreate extends StatefulWidget {
@@ -101,49 +102,33 @@ class _PostCreateState extends State<PostCreate> {
   // 게시글 작성
   void post() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    final accessToken = prefs.getString('accessToken');
-    final refreshToken = prefs.getString('refreshToken');
+    final userId = prefs.getInt('userId');
 
     // 이미지 업로드하고 URL 리스트 받아오기
     final imageUrls = await uploadImages();
 
-    final response = await http.post(
+    final response = await sendHttpRequest(
+      'POST',
       Uri.http(dotenv.env['API_URL']!, '/api/post'),
-      // Uri.parse(url),
-      headers: <String, String>{
-        "Content-Type": "application/json",
-        'Authorization': 'Bearer $accessToken',
-      },
       body: jsonEncode({
-        'user_id' : 1,   // 코드 수정 필요
+        'user_id' : userId,
         'board_id': 1, // 코드 수정 필요
         'post_title': titleController.text,
-        'user_nickname': 'test1', // 코드 수정 필요
         'post_content': contentController.text,
         'post_image_list': imageUrls
-        // 코드 수정 필요
       }),
     );
 
     // 작성 성공
-    if (response.statusCode == 200) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(PostMessage.postSuccess),
-        ),
-      );
-      titleController.clear();
-      contentController.clear();
-      _images.clear();
-      router.pop();
-    } else {
-      // HTTP 요청이 실패했다면,
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(PostMessage.postFail),
-        ),
-      );
-    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text(PostMessage.postSuccess),
+      ),
+    );
+    titleController.clear();
+    contentController.clear();
+    _images.clear();
+    router.pop();
   }
 
   @override

--- a/frontend/lib/presentation/Board/post_detail.dart
+++ b/frontend/lib/presentation/Board/post_detail.dart
@@ -10,14 +10,9 @@ import 'package:orury/presentation/Board/post.dart';
 import 'package:orury/presentation/Board/post_update.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../global/http/http_request.dart';
 import '../main/main_screen.dart';
 
-
-// StatelessWidget 맨 밑 } 주석처리
-// class PostDetail extends StatelessWidget {
-//   final int id;
-//
-//   PostDetail(this.id, {super.key});
 
 class PostDetail extends StatefulWidget {
   final int id;
@@ -47,26 +42,16 @@ class _PostDetailState extends State<PostDetail> {
 
   // 게시글 상세 조회
   Future<Post> fetchPost() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    final accessToken = prefs.getString('accessToken');
-    final refreshToken = prefs.getString('refreshToken');
-
-    final response = await http.get(
-      Uri.http(dotenv.env['API_URL']!, '/api/post/' + widget.id.toString()),
-      headers: {
-        "Content-Type": "application/json",
-        'Authorization': 'Bearer $accessToken',
-      },
+    final response = await sendHttpRequest(
+      'GET',
+      Uri.http(dotenv.env['API_URL']!, '/api/post/${widget.id}'),
     );
 
-    if (response.statusCode == 200) {
-      final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
-      final post = Post.fromJson(jsonData);
-      return post;
-    } else {
-      throw Exception('Failed to load post detail');
-    }
+    final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
+    final post = Post.fromJson(jsonData);
+    return post;
   }
+
 
   // 사진 클릭 시 확대 기능
   void _showDialog(BuildContext context, String url) {
@@ -80,44 +65,27 @@ class _PostDetailState extends State<PostDetail> {
 
   // 게시글 삭제
   Future<void> deletePost() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    final accessToken = prefs.getString('accessToken');
-    final refreshToken = prefs.getString('refreshToken');
-
-    final response = await http.delete(
-      Uri.http(dotenv.env['API_URL']!, '/api/post/' + widget.id.toString()),
-      headers: {
-        "Content-Type": "application/json",
-        'Authorization': 'Bearer $accessToken',
-      },
+    final response = await sendHttpRequest(
+      'DELETE',
+      Uri.http(dotenv.env['API_URL']!, '/api/post/${widget.id}'),
     );
 
-    if (response.statusCode == 200) {
-      // router.pop();
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(builder: (context) => MainScreen()),
-      );
-    } else {
-      throw Exception('Failed to delete post');
-    }
+    // router.pop();
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (context) => MainScreen()),
+    );
   }
 
   // 댓글 작성
   Future<void> commentCreate() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    final accessToken = prefs.getString('accessToken');
-    final refreshToken = prefs.getString('refreshToken');
-    final nickname = prefs.getString('nickname');
     final userId = prefs.getInt('userId');
+    final nickname = prefs.getString('nickname');
 
-
-    final response = await http.post(
+    final response = await sendHttpRequest(
+      'POST',
       Uri.http(dotenv.env['API_URL']!, '/api/comment'),
-      headers: {
-        "Content-Type": "application/json",
-        'Authorization': 'Bearer $accessToken',
-      },
       body: jsonEncode({
         "user_id": userId,
         "post_id": widget.id,
@@ -126,29 +94,18 @@ class _PostDetailState extends State<PostDetail> {
       }),
     );
 
-    if (response.statusCode == 200) {
-      // final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
-      // final post = Post.fromJson(jsonData);
-      commentController.clear();
-    } else {
-      throw Exception('Failed to create comment');
-    }
+    commentController.clear();
   }
 
   // 댓글 수정
   Future<void> commentUpdate(int comId) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    final accessToken = prefs.getString('accessToken');
-    final refreshToken = prefs.getString('refreshToken');
-    final nickname = prefs.getString('nickname');
     final userId = prefs.getInt('userId');
+    final nickname = prefs.getString('nickname');
 
-    final response = await http.patch(
+    final response = await sendHttpRequest(
+      'PATCH',
       Uri.http(dotenv.env['API_URL']!, '/api/comment'),
-      headers: {
-        "Content-Type": "application/json",
-        'Authorization': 'Bearer $accessToken',
-      },
       body: jsonEncode({
         "id": comId,
         "user_id": userId,
@@ -157,55 +114,33 @@ class _PostDetailState extends State<PostDetail> {
       }),
     );
 
-    if (response.statusCode == 200) {
-      // final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
-      // final post = Post.fromJson(jsonData);
-      commentController.clear();
-    } else {
-      throw Exception('Failed to update comment');
-    }
+    commentController.clear();
   }
 
   // 댓글 삭제
   Future<void> deleteComment(int commentId) async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    final accessToken = prefs.getString('accessToken');
-    final refreshToken = prefs.getString('refreshToken');
-
-    final response = await http.delete(
+    final response = await sendHttpRequest(
+      'DELETE',
       Uri.http(dotenv.env['API_URL']!, '/api/comment/' + commentId.toString()),
-      headers: {
-        "Content-Type": "application/json",
-        'Authorization': 'Bearer $accessToken',
-      },
     );
 
-    if (response.statusCode == 200) {
-      // router.pop();
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(builder: (context) => PostDetail(widget.id)),
-      );
-    } else {
-      throw Exception(CommentMessage.commentFail);
-    }
+    // router.pop();
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (context) => PostDetail(widget.id)),
+    );
   }
 
   // 대댓글 작성
   Future<void> replyCreate(int comId) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    final accessToken = prefs.getString('accessToken');
-    final refreshToken = prefs.getString('refreshToken');
-    final nickname = prefs.getString('nickname');
     final userId = prefs.getInt('userId');
+    final nickname = prefs.getString('nickname');
 
-    final response = await http.post(
+    final response = await sendHttpRequest(
+      'POST',
       Uri.http(dotenv.env['API_URL']!, '/api/comment'),
-      headers: {
-        "Content-Type": "application/json",
-        'Authorization': 'Bearer $accessToken',
-      },
-      body: jsonEncode({      // 현재 user_id가 1로 들어가는 중
+      body: jsonEncode({
         "id": comId,
         "user_id": userId,
         "post_id": widget.id,
@@ -214,14 +149,9 @@ class _PostDetailState extends State<PostDetail> {
       }),
     );
 
-    if (response.statusCode == 200) {
-      // final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
-      // final post = Post.fromJson(jsonData);
-      commentController.clear();
-    } else {
-      throw Exception('Failed to create reply');
-    }
+    commentController.clear();
   }
+
 
   @override
   Widget build(BuildContext context) {

--- a/frontend/lib/presentation/Board/post_detail.dart
+++ b/frontend/lib/presentation/Board/post_detail.dart
@@ -33,6 +33,18 @@ class _PostDetailState extends State<PostDetail> {
 
   TextEditingController commentController = TextEditingController();
 
+  late SharedPreferences prefs;
+
+  @override
+  void initState() {
+    super.initState();
+    _initSharedPreferences();
+  }
+
+  Future<void> _initSharedPreferences() async {
+    prefs = await SharedPreferences.getInstance();
+  }
+
   // 게시글 상세 조회
   Future<Post> fetchPost() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -96,6 +108,9 @@ class _PostDetailState extends State<PostDetail> {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     final accessToken = prefs.getString('accessToken');
     final refreshToken = prefs.getString('refreshToken');
+    final nickname = prefs.getString('nickname');
+    final userId = prefs.getInt('userId');
+
 
     final response = await http.post(
       Uri.http(dotenv.env['API_URL']!, '/api/comment'),
@@ -103,10 +118,11 @@ class _PostDetailState extends State<PostDetail> {
         "Content-Type": "application/json",
         'Authorization': 'Bearer $accessToken',
       },
-      body: jsonEncode({      // 현재 user_id가 1로 들어가는 중
+      body: jsonEncode({
+        "user_id": userId,
         "post_id": widget.id,
         "comment_content": commentController.text,
-        "user_nickname": "test1" //코드 수정 필요
+        "user_nickname": nickname
       }),
     );
 
@@ -124,6 +140,8 @@ class _PostDetailState extends State<PostDetail> {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     final accessToken = prefs.getString('accessToken');
     final refreshToken = prefs.getString('refreshToken');
+    final nickname = prefs.getString('nickname');
+    final userId = prefs.getInt('userId');
 
     final response = await http.patch(
       Uri.http(dotenv.env['API_URL']!, '/api/comment'),
@@ -131,10 +149,11 @@ class _PostDetailState extends State<PostDetail> {
         "Content-Type": "application/json",
         'Authorization': 'Bearer $accessToken',
       },
-      body: jsonEncode({      // 현재 user_id가 1로 들어가는 중
+      body: jsonEncode({
         "id": comId,
+        "user_id": userId,
         "comment_content": commentController.text,
-        "user_nickname": "test1" //코드 수정 필요
+        "user_nickname": nickname
       }),
     );
 
@@ -177,6 +196,8 @@ class _PostDetailState extends State<PostDetail> {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     final accessToken = prefs.getString('accessToken');
     final refreshToken = prefs.getString('refreshToken');
+    final nickname = prefs.getString('nickname');
+    final userId = prefs.getInt('userId');
 
     final response = await http.post(
       Uri.http(dotenv.env['API_URL']!, '/api/comment'),
@@ -186,9 +207,10 @@ class _PostDetailState extends State<PostDetail> {
       },
       body: jsonEncode({      // 현재 user_id가 1로 들어가는 중
         "id": comId,
+        "user_id": userId,
         "post_id": widget.id,
         "comment_content": commentController.text,
-        "user_nickname": "test" //코드 수정 필요
+        "user_nickname": nickname
       }),
     );
 
@@ -200,7 +222,6 @@ class _PostDetailState extends State<PostDetail> {
       throw Exception('Failed to create reply');
     }
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -263,9 +284,11 @@ class _PostDetailState extends State<PostDetail> {
                                 style: TextStyle(
                                     fontSize: 20,
                                     fontWeight: FontWeight.bold)), // 제목
+                            (post.userId == prefs.getInt('userId') || 'ROLE_ADMIN' == prefs.getString('role')) ?
                             PopupMenuButton<String>(
                               onSelected: (String result) {
                                 if (result == 'edit') {
+                                  // 게시글 수정 기능 구현
                                   // Navigator.push(
                                   //   context,
                                   //   MaterialPageRoute(
@@ -297,7 +320,8 @@ class _PostDetailState extends State<PostDetail> {
                                   child: Text('삭제'),
                                 ),
                               ],
-                            ),
+                            )
+                            : Container(),
                           ],
                         ),
                         Text(
@@ -322,6 +346,7 @@ class _PostDetailState extends State<PostDetail> {
                           Expanded(
                             child: Text(comment.commentContent),
                           ),
+                          (comment.userId == prefs.getInt('userId') || 'ROLE_ADMIN' == prefs.getString('role')) ?
                           PopupMenuButton<String>(
                             onSelected: (String result) {
                               if (result == 'edit') {
@@ -406,7 +431,8 @@ class _PostDetailState extends State<PostDetail> {
                                 child: Text('삭제'),
                               ),
                             ],
-                          ),
+                          )
+                          : Container(),
                         ],
                       ),
                       subtitle: Column(

--- a/frontend/lib/presentation/main/main_screen.dart
+++ b/frontend/lib/presentation/main/main_screen.dart
@@ -5,6 +5,7 @@ import 'package:orury/core/theme/constant/app_colors.dart';
 import 'package:orury/presentation/routes/route_path.dart';
 import 'package:http/http.dart' as http;
 
+import '../../global/http/http_request.dart';
 import '../Board/board.dart';
 import '../Board/post.dart';
 import '../Board/post_detail.dart';
@@ -12,10 +13,6 @@ import '../routes/routes.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';
-
-// StatelessWidget 맨밑 }도 주석처리
-// class MainScreen extends StatelessWidget {
-//   const MainScreen({super.key});
 
 
 class MainScreen extends StatefulWidget {
@@ -27,43 +24,18 @@ class MainScreen extends StatefulWidget {
 
 class _MainScreenState extends State<MainScreen> {
 
+  // 게시글 목록 조회
   Future<List<Post>> fetchPosts() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    // await prefs.remove('jwtToken');
-    final accessToken = prefs.getString('accessToken');
-
-    final response = await http.get(
+    final response = await sendHttpRequest(
+      'GET',
       Uri.http(dotenv.env['API_URL']!, '/api/board/1'),
-      headers: {
-        "Content-Type": "application/json",
-        'Authorization': 'Bearer $accessToken',
-      },
     );
 
-    if (response.statusCode == 200) {
-      final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
-      final board = Board.fromJson(jsonData);
-      return board.postList;
-    // accessToken 기간 만료에 대한 코드임. 길어질거 같아 일단 냅둠
-    // } else if (response.statusCode == 205) {  // 임시 statusCode.
-    //   final refreshToken = prefs.getString('refreshToken');
-    //
-    //   final tokenresponse = await http.post(
-    //     Uri.http(dotenv.env['API_URL']!, '/api/auth/refreshToken'),
-    //     headers: {
-    //     "Content-Type": "application/json",
-    //     'Authorization': 'Bearer $refreshToken',
-    //     },
-    //   );
-    //
-    //   if (tokenresponse.statusCode == 200) {
-    //     String? newAccessToken = tokenresponse.headers['newAccessToken'];  // 임시 key.
-    //     // await prefs.setString("accessToken", newAccessToken);
-    //   }
-    } else { // 추가적으로 에러 처리가 필요
-      throw Exception('Failed to load posts');
-    }
+    final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
+    final board = Board.fromJson(jsonData);
+    return board.postList;
   }
+
 
   @override
   Widget build(BuildContext context) {

--- a/frontend/lib/presentation/main/main_screen.dart
+++ b/frontend/lib/presentation/main/main_screen.dart
@@ -31,7 +31,6 @@ class _MainScreenState extends State<MainScreen> {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     // await prefs.remove('jwtToken');
     final accessToken = prefs.getString('accessToken');
-    final refreshToken = prefs.getString('refreshToken');
 
     final response = await http.get(
       Uri.http(dotenv.env['API_URL']!, '/api/board/1'),
@@ -45,7 +44,23 @@ class _MainScreenState extends State<MainScreen> {
       final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
       final board = Board.fromJson(jsonData);
       return board.postList;
-    } else {
+    // accessToken 기간 만료에 대한 코드임. 길어질거 같아 일단 냅둠
+    // } else if (response.statusCode == 205) {  // 임시 statusCode.
+    //   final refreshToken = prefs.getString('refreshToken');
+    //
+    //   final tokenresponse = await http.post(
+    //     Uri.http(dotenv.env['API_URL']!, '/api/auth/refreshToken'),
+    //     headers: {
+    //     "Content-Type": "application/json",
+    //     'Authorization': 'Bearer $refreshToken',
+    //     },
+    //   );
+    //
+    //   if (tokenresponse.statusCode == 200) {
+    //     String? newAccessToken = tokenresponse.headers['newAccessToken'];  // 임시 key.
+    //     // await prefs.setString("accessToken", newAccessToken);
+    //   }
+    } else { // 추가적으로 에러 처리가 필요
       throw Exception('Failed to load posts');
     }
   }

--- a/frontend/lib/presentation/pages/user/login_page.dart
+++ b/frontend/lib/presentation/pages/user/login_page.dart
@@ -54,6 +54,30 @@ class _LoginPageState extends State<LoginPage> {
           content: Text('어서오세요!'),
         ),
       );
+
+      final userResponse = await http.get(
+        Uri.http(dotenv.env['API_URL']!, '/api/user/user'),
+        headers: <String, String>{
+          "Content-Type": "application/json",
+          'Authorization': 'Bearer $accessToken',
+        },
+      );
+
+      if (userResponse.statusCode == 200) {
+        var userData = jsonDecode(userResponse.body);
+        int userId = userData['id'];
+        String nickname = userData['nickname'];
+        String role = userData['authority_dto_set'][0]['name'];
+        // SharedPreferences prefs = await SharedPreferences.getInstance();
+        // await prefs.setString('userId', userId.toString());
+        await prefs.setString('nickname', nickname);
+        await prefs.setInt('userId', userId);
+        await prefs.setString('role', role);
+
+      } else {
+        // 다시 로그인하거나 다시 시도하게끔? 해야하나
+      }
+
       emailController.clear();
       passwordController.clear();
       router.go(RoutePath.main);

--- a/frontend/lib/presentation/pages/user/login_page.dart
+++ b/frontend/lib/presentation/pages/user/login_page.dart
@@ -56,7 +56,7 @@ class _LoginPageState extends State<LoginPage> {
       );
 
       final userResponse = await http.get(
-        Uri.http(dotenv.env['API_URL']!, '/api/user/user'),
+        Uri.http(dotenv.env['API_URL']!, '/api/user/info'),
         headers: <String, String>{
           "Content-Type": "application/json",
           'Authorization': 'Bearer $accessToken',


### PR DESCRIPTION
## 개요
유저정보를 프론트엔드에 캐싱함으로써 유저정보를 이용한 코드를 구현하기 위함
accessToken이 만료되었을 때 refreshToken을 이용하여 새로 accessToken을 발급받는 코드를 구현하기 위

Resolves: #106 #112 

### 상세내용
- 로그인이 성공적으로 되면 user정보를 api 요청하는 로직 추가
- SharedPreferences를 이용하여 유저 정보 캐싱
- 캐싱하는 정보는 userId, nickname, role
- 그에 따른 백엔드의 UserDto의 builder에 nickname 추가
- 유저 정보가 필요한 api 요청에 캐싱한 정보를 넣음
- 자신이 작성한 글이거나 role이 admin일 때만 수정/삭제 버튼을 볼 수 있게 변경
- 댓글과 답글은 cacade 관계가 아니기 때문에 댓글을 삭제했는데 해당 댓글의 답글이 남아있는 문제 발견
- 토큰 만료 응답인지 아닌지는 임시로 statusCode == 205으로 판단
- api 요청 부분이 중복코드가 많아 요청 틀을 따로 global/http에 요청 파일(http_request) 생성
- 에러 처리는 임시로 상태 코드 반환으로 변경

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://quickest-asterisk-75d.notion.site/2a977a0d71db4062bc705dc199ebff13?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
