### PR TITLE
[Refactor] #124. 댓글 순서를 위한 매핑작업, [Fix] #126. 올바른 댓글 순서 보여주기

### DIFF
--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostEntity.java
@@ -43,6 +43,6 @@ public class PostEntity extends BaseEntity {
 
 	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
 	@Builder.Default
-	@OrderBy(clause = "id desc")
+	@OrderBy(clause = "id asc")
 	private List<CommentEntity> commentList = List.of();
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/model/PostDto.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/model/PostDto.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.kernel360.orury.domain.comment.model.CommentDto;
 import lombok.*;
 
+import javax.persistence.criteria.CriteriaBuilder;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Setter
@@ -31,4 +33,5 @@ public class PostDto {
 	private String thumbnailUrl;
 	private List<String> imageList = List.of();
 	private List<CommentDto> commentList = List.of();
+	private Map<String, List<CommentDto>> commentMap = Map.of();
 }

--- a/frontend/lib/presentation/Board/post.dart
+++ b/frontend/lib/presentation/Board/post.dart
@@ -1,4 +1,6 @@
 // 게시물 데이터 모델
+import 'dart:ffi';
+
 import 'package:orury/presentation/Board/comment.dart';
 
 class Post {
@@ -13,11 +15,13 @@ class Post {
   final int likeCnt;
   final int userId;
   final List<Comment> commentList;
+  final Map<String, List<Comment>> commentMap;
 
   // Post(this.id, this.boardId, this.postTitle, this.postContent,
   //     this.userNickname, this.viewCnt, this.likeCnt, this.userId);
 
-  Post({required this.id,
+  Post({
+      required this.id,
       required this.boardId,
       required this.postTitle,
       required this.postContent,
@@ -27,12 +31,24 @@ class Post {
       required this.viewCnt,
       required this.likeCnt,
       required this.userId,
-      required this.commentList});
+      required this.commentList,
+      required this.commentMap
+  });
 
   //
   factory Post.fromJson(Map<String, dynamic> json) {
     var commentList = json['comment_list'] as List;
     List<Comment> commentObjects = commentList.map((comment) => Comment.fromJson(comment)).toList();
+
+    final Map<String, List<Comment>> commentMap2 = {};
+    var commentMapJson = json['comment_map'] as Map;
+
+    for (var key in commentMapJson.keys) {
+      var commentMapList = commentMapJson[key] as List;
+      List<Comment> commentMapListObjects = commentMapList.map((comment) => Comment.fromJson(comment)).toList();
+      commentMap2[key] = commentMapListObjects; // 여기서 Long은 Dart에 기본적으로 제공되는 타입이 아닙니다.
+    }
+
 
     return Post(
         id: json['id'],
@@ -45,6 +61,8 @@ class Post {
         viewCnt: json['view_cnt'],
         likeCnt: json['like_cnt'],
         userId: json['user_id'],
-        commentList: commentObjects);
+        commentList: commentObjects,
+        commentMap: commentMap2
+    );
   }
 }

--- a/frontend/lib/presentation/main/main_screen.dart
+++ b/frontend/lib/presentation/main/main_screen.dart
@@ -88,7 +88,7 @@ class _MainScreenState extends State<MainScreen> {
                       Text(post.likeCnt.toString()), // 좋아요 수
                       SizedBox(width: 20), // 간격 조절
                       Icon(Icons.comment, size: 15,), // 댓글 아이콘
-                      Text(post.commentList.length.toString()), // 댓글 수
+                      Text((post.commentMap['0']?.length).toString()),
                     ],
                   ),
                 );


### PR DESCRIPTION
## 개요
프론트의 댓글 순서 문제를 java Map으로 해결하고자 함

### 상세 내용
- 백엔드의 PostEntitiy, PostDto, PostConverter 수정
- PostDto에서 매핑
- key값은 "0" or 본댓글의 id
- 프론트엔드의 post 수정

- 매핑 정보를 이용함
- 화면상 댓글을 지우면 해당하는 대댓글도 지워지나 DB에 해당 대댓글이 남아있는 문제가 있음
- 수정으로 인해 현재 post의 commentList 사용하지 않음

Resolves: #124 #126

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://quickest-asterisk-75d.notion.site/2a977a0d71db4062bc705dc199ebff13?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
