### PR TITLE
[feat] #109 리프레시 토큰과 엑세스 토큰 유효성 확인 로직 변경

### DIFF
--- a/backend/orury/src/main/java/com/kernel360/orury/config/jwt/JwtFilter.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/config/jwt/JwtFilter.java
@@ -2,7 +2,7 @@ package com.kernel360.orury.config.jwt;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kernel360.orury.global.exception.TokenExpiredException;
+import com.kernel360.orury.global.constants.Constant;
 import com.kernel360.orury.global.message.errors.ErrorMessages;
 import io.jsonwebtoken.ExpiredJwtException;
 import org.slf4j.Logger;
@@ -12,6 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
 
@@ -23,11 +24,10 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 
-public class JwtFilter extends GenericFilterBean {
+public class JwtFilter extends OncePerRequestFilter {
 
 	private static final Logger logger = LoggerFactory.getLogger(JwtFilter.class);
-	public static final String AUTHORIZATION_HEADER = "Authorization";
-	private TokenProvider tokenProvider;
+	private final TokenProvider tokenProvider;
 
 	public JwtFilter(TokenProvider tokenProvider) {
 		this.tokenProvider = tokenProvider;
@@ -35,51 +35,81 @@ public class JwtFilter extends GenericFilterBean {
 
 	//토큰의 인증정보를 SecurityContext에 저장
 	@Override
-	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws
+	public void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse, FilterChain filterChain) throws
 		IOException,
 		ServletException {
-		HttpServletRequest httpServletRequest = (HttpServletRequest)servletRequest;
-		String jwt = resolveToken(httpServletRequest);
-		String requestURI = httpServletRequest.getRequestURI();
 
-		try{
-			if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
-				Authentication authentication = tokenProvider.getAuthentication(jwt);
-				SecurityContextHolder.getContext().setAuthentication(authentication);
-				logger.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
-			}
-		} catch (ExpiredJwtException e) {
+		String authorizationHeader = servletRequest.getHeader(Constant.AUTHORIZATION.getMessage());
+		String refreshHeader = servletRequest.getHeader(Constant.REFRESH_HEADER.getMessage());
 
-			HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
-			String errorMessage = ErrorMessages.EXPIRED_JWT.getMessage();
-			// Create an ObjectMapper
-			ObjectMapper objectMapper = new ObjectMapper();
-			// Create a JSON object
-			JsonNode errorJson = objectMapper.createObjectNode()
-					.put("error", errorMessage)
-					.put("errorCode", HttpStatus.UNAUTHORIZED.value());
-			// Convert JSON object to string
-			String jsonString = objectMapper.writeValueAsString(errorJson);
-			// Set status code and headers
-			httpServletResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
-			httpServletResponse.setContentType("application/json; charset=UTF-8");
-			httpServletResponse.setCharacterEncoding("UTF-8");
-			// Write JSON string to the response body
-			httpServletResponse.getWriter().write(jsonString);
-			httpServletResponse.getWriter().flush();
-			return;
+		// 헤더가 비었으면 user-password 필터로 이동
+		if (!StringUtils.hasText(authorizationHeader) && !StringUtils.hasText(refreshHeader)){
+			filterChain.doFilter(servletRequest, servletResponse);
+			return ;
 		}
+
+		String refreshToken ="";
+		if(StringUtils.hasText(refreshHeader)) {
+			refreshToken = resolveToken(refreshHeader);
+		}
+
+		String accessToken = resolveToken(authorizationHeader);
+
+		if (StringUtils.hasText(refreshToken)){
+			try{
+				tokenProvider.validateToken(refreshToken);
+			} catch (ExpiredJwtException e) {
+				// Create an ObjectMapper
+				ObjectMapper objectMapper = new ObjectMapper();
+				// Create a JSON object
+				JsonNode errorJson = objectMapper.createObjectNode()
+						.put("error", ErrorMessages.EXPIRED_REFRESH_JWT.getMessage())
+						.put("errorCode", 402);
+				// Convert JSON object to string
+				tempResponse(objectMapper, errorJson, servletResponse);
+				return;
+			}
+		}else {
+			try {
+				tokenProvider.validateToken(accessToken);
+			} catch (ExpiredJwtException e) {
+				// Create an ObjectMapper
+				ObjectMapper objectMapper = new ObjectMapper();
+				// Create a JSON object
+				JsonNode errorJson = objectMapper.createObjectNode()
+						.put("error", ErrorMessages.EXPIRED_JWT.getMessage())
+						.put("errorCode", 401);
+				// Convert JSON object to string
+				tempResponse(objectMapper, errorJson, servletResponse);
+				return;
+			}
+		}
+
+        assert accessToken != null;
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		logger.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), servletRequest.getRequestURI());
+
 		filterChain.doFilter(servletRequest, servletResponse);
 	}
 
+	private static void tempResponse(ObjectMapper objectMapper, JsonNode errorJson, HttpServletResponse httpServletResponse) throws IOException {
+		String jsonString = objectMapper.writeValueAsString(errorJson);
+		// Set status code and headers
+		httpServletResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
+		httpServletResponse.setContentType("application/json; charset=UTF-8");
+		httpServletResponse.setCharacterEncoding("UTF-8");
+		// Write JSON string to the response body
+		httpServletResponse.getWriter().write(jsonString);
+		httpServletResponse.getWriter().flush();
+    }
+
 	//리퀘스트 헤더에서 토큰 정보를 꺼내온다
-	private String resolveToken(HttpServletRequest request) {
-		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-
-		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-			return bearerToken.substring(7);
+	private String resolveToken(String authorizationHeader) {
+		if(StringUtils.hasText(authorizationHeader)) {
+			return authorizationHeader.startsWith("Bearer ") ? authorizationHeader.substring(7) : authorizationHeader;
 		}
+		else return null;
+    }
 
-		return null;
-	}
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/user/controller/AuthController.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/user/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.kernel360.orury.domain.user.controller;
 
 import javax.validation.Valid;
+
+import com.kernel360.orury.global.constants.Constant;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,7 +11,6 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-import com.kernel360.orury.config.jwt.JwtFilter;
 import com.kernel360.orury.config.jwt.TokenProvider;
 import com.kernel360.orury.domain.user.model.LoginDto;
 import com.kernel360.orury.domain.user.model.TokenDto;
@@ -39,8 +40,8 @@ public class AuthController {
 		tokenProvider.storeToken(refreshToken);
 
 		HttpHeaders httpHeaders = new HttpHeaders();
-		httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + accessToken);
-		httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + refreshToken);
+		httpHeaders.add(Constant.AUTHORIZATION.getMessage(), "Bearer " + accessToken);
+		httpHeaders.add(Constant.REFRESH_HEADER.getMessage(), "Bearer " + refreshToken);
 
 		var tokenDto = TokenDto.builder()
 				.accessToken(accessToken)
@@ -52,7 +53,7 @@ public class AuthController {
 
 	@PostMapping("/refreshToken")
 	public ResponseEntity<TokenDto> refreshAccessToken(
-			@RequestHeader("Authorization") String refreshTokenHeader
+			@RequestHeader("Refresh-Token") String refreshTokenHeader
 	){
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		//서버 측에서 리프레시 토큰 검증

--- a/backend/orury/src/main/java/com/kernel360/orury/global/constants/Constant.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/global/constants/Constant.java
@@ -7,7 +7,15 @@ public enum Constant {
     ADMIN("admin"),
     SYSTEM("system"),
     ROLE_USER("ROLE_USER"),
-    ROLE_ADMIN("ROLE_ADMIN")
+    ROLE_ADMIN("ROLE_ADMIN"),
+
+
+    // userInfo 등 하드 코딩된 것 상수로
+    USERID("userId"),
+
+    // header 종류
+    AUTHORIZATION("Authorization"),
+    REFRESH_HEADER("Refresh-token")
     ;
 
     private final String message;


### PR DESCRIPTION
- JwtFilter 헤더에 엑세스 토큰만 있을 때와 리프레시 토큰이 있을 때 유효성 검사를 변경

## 개요
로그인 프로세스에를 원활히 하기 위해 엑세스토큰이 만료됐을 때(401)와 리프레시 토큰이 만료됐을 때(402) 다른 메시지를 보내도록 수정

Resolves: #109 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://quickest-asterisk-75d.notion.site/2a977a0d71db4062bc705dc199ebff13?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
