### PR TITLE
[Feat] #154. openAPI 만들기

### DIFF
--- a/backend/orury/src/main/java/com/kernel360/orury/config/SecurityConfig.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
 				.mvcMatchers(SWAGGER.toArray(new String[0])).permitAll()
 				.antMatchers("/assets/**").permitAll()
 				.antMatchers("/admin/**").permitAll()
-				.antMatchers("/api/hello", "/api/auth/login", "/api/user/signup").permitAll()
+				.antMatchers("/api/hello", "/api/auth/login", "/api/user/signup", "/api/board/notice").permitAll()
 				.anyRequest().authenticated()
 			)
 

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/controller/BoardController.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/controller/BoardController.java
@@ -4,8 +4,10 @@ import com.kernel360.orury.domain.board.model.BoardDto;
 import com.kernel360.orury.domain.board.model.BoardRequest;
 import com.kernel360.orury.domain.board.service.BoardService;
 
+import com.kernel360.orury.domain.post.model.PostDto;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -49,10 +51,17 @@ public class BoardController {
 
 	// 특정 게시판 조회
 	@GetMapping("/{id}")
-	public BoardDto getBoard(
+	public ResponseEntity<BoardDto> getBoard(
 		@PathVariable Long id
 	) {
-		return boardService.getBoard(id);
+		return ResponseEntity.ok(boardService.getBoard(id));
+	}
+
+	// 공지 간단 조회
+	@GetMapping("/notice")
+	public ResponseEntity<List<PostDto>> getNoticeBoard(
+	) {
+		return ResponseEntity.ok(boardService.getNoticeBoard(1L));
 	}
 
 	// 게시판 삭제

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
@@ -4,6 +4,10 @@ import com.kernel360.orury.domain.board.db.BoardEntity;
 import com.kernel360.orury.domain.board.db.BoardRepository;
 import com.kernel360.orury.domain.board.model.BoardDto;
 import com.kernel360.orury.domain.board.model.BoardRequest;
+import com.kernel360.orury.domain.post.db.PostEntity;
+import com.kernel360.orury.domain.post.db.PostRepository;
+import com.kernel360.orury.domain.post.model.PostDto;
+import com.kernel360.orury.domain.post.service.PostConverter;
 import com.kernel360.orury.global.constants.Constant;
 import com.kernel360.orury.global.message.errors.ErrorMessages;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +22,8 @@ public class BoardService {
 
 	public final BoardRepository boardRepository;
 	public final BoardConverter boardConverter;
+	public final PostRepository postRepository;
+	public final PostConverter postConverter;
 
 	public BoardDto createBoard(
 		BoardRequest boardRequest
@@ -69,5 +75,16 @@ public class BoardService {
 			.orElseThrow(() -> new RuntimeException(ErrorMessages.THERE_IS_NO_BOARD.getMessage() + id));
 
 		return boardConverter.toDto(entity);
+	}
+
+	public List<PostDto> getNoticeBoard(Long id) {
+		var noticeList = postRepository.findAllByBoardId(id);
+		if(noticeList.isEmpty()) {
+			new RuntimeException(ErrorMessages.THERE_IS_NO_BOARD.getMessage() + id);
+		}
+
+		return noticeList.stream()
+			.map(postConverter::toNoticeDto) // 각 엔티티를 Dto로 변환
+			.toList();
 	}
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostRepository.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostRepository.java
@@ -2,8 +2,10 @@ package com.kernel360.orury.domain.post.db;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
-
+//    Optional<List<PostEntity>> findAllByBoardId(Long boardId);
+    List<PostEntity> findAllByBoardId(Long boardId);
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostConverter.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostConverter.java
@@ -2,6 +2,7 @@ package com.kernel360.orury.domain.post.service;
 
 import com.kernel360.orury.domain.board.db.BoardEntity;
 import com.kernel360.orury.domain.board.db.BoardRepository;
+import com.kernel360.orury.domain.board.model.BoardDto;
 import com.kernel360.orury.domain.comment.model.CommentDto;
 import com.kernel360.orury.domain.comment.model.CommentLikeDto;
 import com.kernel360.orury.domain.comment.service.CommentConverter;
@@ -35,9 +36,9 @@ public class PostConverter {
     public PostDto toDto(PostEntity postEntity) {
 
         var commentList = postEntity.getCommentList()
-                .stream()
-                .map(commentConverter::toDto)
-                .toList();
+            .stream()
+            .map(commentConverter::toDto)
+            .toList();
 
         // map으로 변환
         Map<String, List<CommentDto>> commentMap = new HashMap<>();
@@ -53,7 +54,7 @@ public class PostConverter {
 
         // 게시글 작성자 userNickname 설정을 위한 entity
         UserEntity userEntity = userRepository.findById(postEntity.getUserId())
-                .orElseThrow(() -> new RuntimeException(ErrorMessages.THERE_IS_NO_USER.getMessage() + postEntity.getUserId()));
+            .orElseThrow(() -> new RuntimeException(ErrorMessages.THERE_IS_NO_USER.getMessage() + postEntity.getUserId()));
 
         // 좋아요 수 및 유저 좋아요 세팅
         long loginId = getLoginId();
@@ -61,60 +62,60 @@ public class PostConverter {
         Long likeCnt = postLikeRepository.countByPostLikePKPostId(postEntity.getId());
 
         return PostDto.builder()
-                .id(postEntity.getId())
-                .boardId(postEntity.getBoard().getId())
-                .postTitle(postEntity.getPostTitle())
-                .postContent(postEntity.getPostContent())
-                .userNickname(userEntity.getNickname())
-                .viewCnt(postEntity.getViewCnt())
-                .likeCnt(postEntity.getLikeCnt())
-                .userId(postEntity.getUserId())
-                .thumbnailUrl(postEntity.getThumbnailUrl())
-                .imageList(postEntity.getImages() == null ? List.of() : Arrays.stream(postEntity.getImages().split(","))
-                    .map(image -> getenv().get("IMGUR_URL") + image)
-                    .collect(Collectors.toList()))
-                .commentList(commentList)
-                .commentMap(commentMap)
-                .isLike(isLike)
-                .likeCnt(likeCnt.intValue())
-                .createdBy(postEntity.getCreatedBy())
-                .createdAt(postEntity.getCreatedAt())
-                .updatedBy(postEntity.getUpdatedBy())
-                .updatedAt(postEntity.getUpdatedAt())
-                .build();
+            .id(postEntity.getId())
+            .boardId(postEntity.getBoard().getId())
+            .postTitle(postEntity.getPostTitle())
+            .postContent(postEntity.getPostContent())
+            .userNickname(userEntity.getNickname())
+            .viewCnt(postEntity.getViewCnt())
+            .likeCnt(postEntity.getLikeCnt())
+            .userId(postEntity.getUserId())
+            .thumbnailUrl(postEntity.getThumbnailUrl())
+            .imageList(postEntity.getImages() == null ? List.of() : Arrays.stream(postEntity.getImages().split(","))
+                .map(image -> getenv().get("IMGUR_URL") + image)
+                .collect(Collectors.toList()))
+            .commentList(commentList)
+            .commentMap(commentMap)
+            .isLike(isLike)
+            .likeCnt(likeCnt.intValue())
+            .createdBy(postEntity.getCreatedBy())
+            .createdAt(postEntity.getCreatedAt())
+            .updatedBy(postEntity.getUpdatedBy())
+            .updatedAt(postEntity.getUpdatedAt())
+            .build();
     }
 
     public PostEntity toEntity(PostDto postDto) {
         BoardEntity boardEntity = boardRepository.findById(postDto.getBoardId())
-                .orElseThrow(
-                        () -> new RuntimeException(ErrorMessages.THERE_IS_NO_BOARD.getMessage() + postDto.getBoardId())
-                );
+            .orElseThrow(
+                () -> new RuntimeException(ErrorMessages.THERE_IS_NO_BOARD.getMessage() + postDto.getBoardId())
+            );
 
         return PostEntity.builder()
-                .id(postDto.getId())
-                .board(boardEntity)
-                .postTitle(postDto.getPostTitle())
-                .postContent(postDto.getPostContent())
-                .viewCnt(postDto.getViewCnt())
-                .likeCnt(postDto.getLikeCnt())
-                .userId(postDto.getUserId())
-                .thumbnailUrl(postDto.getThumbnailUrl())
-                .images(postDto.getImageList().equals(List.of()) ? null : postDto.getImageList()
-                    .stream()
-                    .map(s -> s.replaceFirst(getenv().get("IMGUR_URL"), ""))
-                    .collect(Collectors.joining(",")))
-                .createdBy(postDto.getCreatedBy())
-                .createdAt(postDto.getCreatedAt())
-                .updatedBy(postDto.getUpdatedBy())
-                .updatedAt(postDto.getUpdatedAt())
-                .build();
+            .id(postDto.getId())
+            .board(boardEntity)
+            .postTitle(postDto.getPostTitle())
+            .postContent(postDto.getPostContent())
+            .viewCnt(postDto.getViewCnt())
+            .likeCnt(postDto.getLikeCnt())
+            .userId(postDto.getUserId())
+            .thumbnailUrl(postDto.getThumbnailUrl())
+            .images(postDto.getImageList().equals(List.of()) ? null : postDto.getImageList()
+                .stream()
+                .map(s -> s.replaceFirst(getenv().get("IMGUR_URL"), ""))
+                .collect(Collectors.joining(",")))
+            .createdBy(postDto.getCreatedBy())
+            .createdAt(postDto.getCreatedAt())
+            .updatedBy(postDto.getUpdatedBy())
+            .updatedAt(postDto.getUpdatedAt())
+            .build();
     }
 
     public PostLikeDto toLikeDto(PostLikeEntity postLikeEntity) {
         return PostLikeDto.builder()
-                .postId(postLikeEntity.getPostLikePK().getPostId())
-                .userId(postLikeEntity.getPostLikePK().getUserId())
-                .build();
+            .postId(postLikeEntity.getPostLikePK().getPostId())
+            .userId(postLikeEntity.getPostLikePK().getUserId())
+            .build();
     }
 
     // 게시글 좋아요 여부값 가져오기
@@ -128,7 +129,17 @@ public class PostConverter {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String loginEmail = authentication.getName();
         UserEntity loginUser = userRepository.findByEmailAddr(loginEmail)
-                .orElseThrow(() -> new NoSuchElementException(ErrorMessages.THERE_IS_NO_USER.getMessage() + loginEmail));
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessages.THERE_IS_NO_USER.getMessage() + loginEmail));
         return loginUser.getId();
     }
+
+    // 공지 게시글 Dto
+    public PostDto toNoticeDto(PostEntity postEntity) {
+        return PostDto.builder()
+            .id(postEntity.getId())
+            .postTitle(postEntity.getPostTitle())
+            .postContent(postEntity.getPostContent())
+            .build();
+    }
 }
+

--- a/frontend/lib/global/http/http_request.dart
+++ b/frontend/lib/global/http/http_request.dart
@@ -37,7 +37,7 @@ Future<http.Response> sendHttpRequest(String method, Uri uri, {String? body, Map
   if (response.statusCode == 200) { // 응답의 상태 코드가 200인 경우
     return response; // 응답을 그대로 반환
   } else if (response.statusCode == 401) { // 응답의 상태 코드가 401인 경우
-    if (jsonDecode(response.body)['errorCode'] == 401) { // 응답 바디의 errorCode가 401인 경우
+    if (jsonDecode(response.body)['code'] == 401) { // 응답 바디의 errorCode가 401인 경우
       final refreshToken = prefs.getString('refreshToken');
       final tokenResponse = await http.post(
         // Uri.http(dotenv.env['API_URL']!, '/api/auth/refreshToken'),
@@ -57,7 +57,7 @@ Future<http.Response> sendHttpRequest(String method, Uri uri, {String? body, Map
 
         // 재귀 호출하여 새로운 토큰으로 다시 HTTP 요청을 보냅니다.
         return sendHttpRequest(method, uri, body: body, headers: headers);
-      } else if (jsonDecode(tokenResponse.body)['errorCode'] == 402) { // 응답 바디의 errorCode가 402인 경우
+      } else if (jsonDecode(tokenResponse.body)['code'] == 402) { // 응답 바디의 errorCode가 402인 경우
         Set<String> keys = prefs.getKeys();
 
         for (String key in keys) {

--- a/frontend/lib/presentation/Board/notice_detail.dart
+++ b/frontend/lib/presentation/Board/notice_detail.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:orury/core/theme/constant/app_colors.dart';
+
+class NoticeDetail extends StatelessWidget {
+  final String title;
+  final String content;
+
+  NoticeDetail(this.title, this.content, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('공지'),
+        centerTitle: true,
+        backgroundColor: AppColors.error,
+      ),
+      body: Padding(
+        padding: EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: TextStyle(
+                fontSize: 30,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            Divider(),
+            Text(
+              content,
+              style: TextStyle(
+                fontSize: 20,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/presentation/Board/post_detail.dart
+++ b/frontend/lib/presentation/Board/post_detail.dart
@@ -291,7 +291,7 @@ class _PostDetailState extends State<PostDetail> {
                               ),
                             ),
                             // 수정: 좋아요 토글 아이콘
-                            IconButton(
+                            post.boardId != 1 ? IconButton(
                               icon: Icon(
                                 isLike ? Icons.favorite : Icons.favorite_border,
                                 color: isLike ? Colors.red : Colors.grey,
@@ -304,7 +304,7 @@ class _PostDetailState extends State<PostDetail> {
                                 // 추가: 좋아요 상태 업데이트 API 호출
                                 updateLikeStatus(isLike);
                               },
-                            ),
+                            ) : Container(),
                             (post.userId == prefs.getInt('userId') ||
                                     'ROLE_ADMIN' == prefs.getString('role'))
                                 ? PopupMenuButton<String>(
@@ -488,14 +488,14 @@ class _PostDetailState extends State<PostDetail> {
                 },
               ),
             ),
-            floatingActionButton: ElevatedButton(
+            floatingActionButton: post.boardId != 1 ? ElevatedButton(
               child: Text('댓글 달기'),
               onPressed: () {
                 showCommentDialog(onPressed: () {
                   commentCreate();
                 });
               },
-            ),
+            ) : null,
           );
         }
       },

--- a/frontend/lib/presentation/pages/user/login_page.dart
+++ b/frontend/lib/presentation/pages/user/login_page.dart
@@ -14,6 +14,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../routes/route_path.dart';
 import '../../routes/routes.dart';
+import 'notice_slide.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -94,6 +95,9 @@ class _LoginPageState extends State<LoginPage> {
   Widget build(BuildContext context) {
     final size = context.mediaQuerySize;
     return Scaffold(
+      appBar: AppBar(
+        title: MySlidingAppBar(),
+      ),
       body: SingleChildScrollView(
         child: Form(
           key: _formKey,

--- a/frontend/lib/presentation/pages/user/notice.dart
+++ b/frontend/lib/presentation/pages/user/notice.dart
@@ -1,0 +1,15 @@
+class Notice {
+  final int post_id;
+  final String postTitle;
+  final String postContent;
+
+  Notice({required this.post_id, required this.postTitle, required this.postContent});
+
+  factory Notice.fromJson(Map<String, dynamic> json) {
+    return Notice(
+      post_id: json['id'],
+      postTitle: json['post_title'],
+      postContent: json['post_content'],
+    );
+  }
+}

--- a/frontend/lib/presentation/pages/user/notice_slide.dart
+++ b/frontend/lib/presentation/pages/user/notice_slide.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:flutter/cupertino.dart';
+import 'package:orury/presentation/routes/route_path.dart';
+import 'package:orury/presentation/routes/routes.dart';
+
+import 'notice.dart';
+
+class MySlidingAppBar extends StatefulWidget {
+  @override
+  _MySlidingAppBarState createState() => _MySlidingAppBarState();
+}
+
+class _MySlidingAppBarState extends State<MySlidingAppBar> with AutomaticKeepAliveClientMixin {
+  late PageController _pageController;
+  late Timer _timer;
+  late List<Notice> notice_list;
+  int _noticeCount = 0;
+
+  Future<List<Notice>> fetchData() async {
+    final response = await http.get(
+      // Uri.http(dotenv.env['API_URL']!, '/api/board/notice'),
+      Uri.http(dotenv.env['AWS_API_URL']!, '/api/board/notice'),
+      headers: <String, String>{
+        "Content-Type": "application/json",
+      },
+    );
+    if (response.statusCode == 200) {
+      // 응답이 성공적이면, 데이터를 반환합니다.
+      final jsonData = jsonDecode(utf8.decode(response.bodyBytes)) as List;
+      final notices = jsonData.map((boardJson) => Notice.fromJson(boardJson)).toList();
+
+      _noticeCount = notices.length; // 공지사항의 수를 저장
+
+      return notices;
+    } else {
+      // 응답이 실패하면, 에러를 던집니다.
+      throw Exception('Failed to load notice data');
+    }
+  }
+
+  // Future<void> loadNotices() async {
+  //   notice_list = await fetchData();
+  // }
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController();
+    _timer = Timer.periodic(Duration(seconds: 2), (Timer timer) {
+      if (_pageController.page!.round() == _noticeCount - 1) {
+        _pageController.animateToPage(
+          0,
+          duration: Duration(milliseconds: 800),
+          curve: Curves.easeInOut,
+        );
+      } else {
+        _pageController.nextPage(
+          duration: Duration(milliseconds: 800),
+          curve: Curves.easeInOut,
+        );
+      }
+    });
+    // loadNotices();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 50,
+      child:
+          FutureBuilder<List<Notice>>(
+            future: fetchData(),
+            builder: (BuildContext context, AsyncSnapshot<List<Notice>> snapshot) {
+              if (snapshot.hasData) {
+                return PageView.builder(
+                    controller: _pageController,
+                    itemCount: snapshot.data!.length,
+                    itemBuilder: (context, index) {
+                      return GestureDetector(
+                        onTap: () {
+                          router.push(
+                            RoutePath.noticeDetail,
+                            extra: {
+                              'title': snapshot.data![index].postTitle,
+                              'content': snapshot.data![index].postContent
+                            }
+                          );
+                        },
+                        child: Center(child: Text('${snapshot.data![index].postTitle}')),
+                      );
+                    }
+                );
+              } else if (snapshot.hasError) {
+                return Center(child: Text('Error: ${snapshot.error}'));
+              }
+              // 기본적으로 로딩 스피너를 보여줍니다.
+              return CircularProgressIndicator();
+            },
+          ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+}

--- a/frontend/lib/presentation/routes/route_path.dart
+++ b/frontend/lib/presentation/routes/route_path.dart
@@ -7,4 +7,5 @@ class RoutePath {
   static const String postUpdate = '/post/update';
   static const String postDetail = '/post/detail';
   static const String registerPage = '/register';
+  static const String noticeDetail = '/notice';
 }

--- a/frontend/lib/presentation/routes/routes.dart
+++ b/frontend/lib/presentation/routes/routes.dart
@@ -4,6 +4,7 @@ import 'package:orury/presentation/main/main_screen.dart';
 import 'package:orury/presentation/pages/user/login_page.dart';
 import 'package:orury/presentation/routes/route_path.dart';
 
+import '../Board/notice_detail.dart';
 import '../Board/post.dart';
 import '../Board/post_create.dart';
 import '../Board/post_update.dart';
@@ -59,6 +60,17 @@ final GoRouter router = GoRouter(
       builder: (context, state) {
         final postId = state.extra as int?;
         return PostDetail(postId ?? 0);
+      },
+    ),
+
+    GoRoute(
+      path: RoutePath.noticeDetail,
+      name: 'notice_page',
+      builder: (context, state) {
+        final extras = state.extra as Map<String, dynamic>?;
+        final title = extras?['title'] ?? '';
+        final content = extras?['content'] ?? '';
+        return NoticeDetail(title, content);
       },
     ),
 


### PR DESCRIPTION
## 개요
openAPI 전용 기능 개발

### 상세 내용
- openAPI 전용 공지 내용은 로그인 전에 볼 수 있게 함
- 로그인 화면의 상단에 공지 게시글의 제목들이 슬라이드 형식으로 표현
- 슬라이드를 누르면 해당 공지 제목의 게시글 내용도 볼 수 있음
- 공지 게시판에서는 좋아요 댓글 기능 없고 어드민만 게시글 작성 가능
- 공지 게시판 id는 1, 자유 게시판 id는 2로 DB 초기화
- 기능 구현을 위해 백엔드 및 프런트엔드 수정

Resolves: #154 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://quickest-asterisk-75d.notion.site/2a977a0d71db4062bc705dc199ebff13?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
