### PR TITLE
[Refactor] #181. 프론트의 MainScreen이 빌드되는 시간이 오래 걸리는 문제

### DIFF
--- a/backend/orury/src/main/java/com/kernel360/orury/domain/admin/service/AdminPostService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/admin/service/AdminPostService.java
@@ -45,14 +45,14 @@ public class AdminPostService {
 			.build();
 		var saveEntity = postRepository.save(entity);
 
-		return postConverter.toDto(saveEntity, false);
+		return postConverter.toDto(saveEntity);
 	}
 
 	public PostDto getPost(Long id) {
 		Optional<PostEntity> postEntityOptional = postRepository.findById(id);
 		PostEntity post = postEntityOptional.orElseThrow(
 			() -> new BusinessException(PostErrorCode.THERE_IS_NO_POST));
-		return postConverter.toDto(post, false);
+		return postConverter.toDto(post);
 	}
 
 	public PostDto updatePost(
@@ -62,7 +62,7 @@ public class AdminPostService {
 		var postEntityOptional = postRepository.findById(postId);
 		var entity = postEntityOptional.orElseThrow(
 			() -> new BusinessException(PostErrorCode.THERE_IS_NO_POST));
-		var dto = postConverter.toDto(entity, false);
+		var dto = postConverter.toDto(entity);
 		dto.setPostTitle(postRequest.getPostTitle());
 		dto.setPostContent(postRequest.getPostContent());
 		dto.setUpdatedBy(Constant.ADMIN.getMessage());
@@ -83,7 +83,7 @@ public class AdminPostService {
 		var entityList = postRepository.findAll();
 
 		return entityList.stream()
-			.map((PostEntity postEntity) -> postConverter.toDto(postEntity, false))
+			.map(postConverter::toDto)
 			.toList();
 	}
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/admin/service/AdminPostService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/admin/service/AdminPostService.java
@@ -45,14 +45,14 @@ public class AdminPostService {
 			.build();
 		var saveEntity = postRepository.save(entity);
 
-		return postConverter.toDto(saveEntity);
+		return postConverter.toDto(saveEntity, false);
 	}
 
 	public PostDto getPost(Long id) {
 		Optional<PostEntity> postEntityOptional = postRepository.findById(id);
 		PostEntity post = postEntityOptional.orElseThrow(
 			() -> new BusinessException(PostErrorCode.THERE_IS_NO_POST));
-		return postConverter.toDto(post);
+		return postConverter.toDto(post, false);
 	}
 
 	public PostDto updatePost(
@@ -62,7 +62,7 @@ public class AdminPostService {
 		var postEntityOptional = postRepository.findById(postId);
 		var entity = postEntityOptional.orElseThrow(
 			() -> new BusinessException(PostErrorCode.THERE_IS_NO_POST));
-		var dto = postConverter.toDto(entity);
+		var dto = postConverter.toDto(entity, false);
 		dto.setPostTitle(postRequest.getPostTitle());
 		dto.setPostContent(postRequest.getPostContent());
 		dto.setUpdatedBy(Constant.ADMIN.getMessage());
@@ -83,7 +83,7 @@ public class AdminPostService {
 		var entityList = postRepository.findAll();
 
 		return entityList.stream()
-			.map(postConverter::toDto)
+			.map((PostEntity postEntity) -> postConverter.toDto(postEntity, false))
 			.toList();
 	}
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/db/BoardEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/db/BoardEntity.java
@@ -28,8 +28,8 @@ public class BoardEntity extends BaseEntity {
 	private Long id;
 	private String boardTitle;
 
-	@OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
-	@Builder.Default
-	@OrderBy(clause = "id desc")
-	private List<PostEntity> postList = List.of();
+//	@OneToMany(mappedBy = "board", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//	@Builder.Default
+//	@OrderBy(clause = "id desc")
+//	private List<PostEntity> postList = List.of();
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardConverter.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardConverter.java
@@ -22,18 +22,12 @@ public class BoardConverter {
 	private final PostRepository postRepository;
 	private final PostConverter postConverter;
 
-	public BoardDto toDto(BoardEntity boardEntity, boolean bool) {
-		List<PostDto> postList = List.of();
-		if (bool) {
-			postList = postRepository.findAllByBoardIdOrderByIdDesc(boardEntity.getId())
-				.stream()
-				.map(postEntity -> {
-					PostDto postDto = postConverter.toDto(postEntity, !bool);
-//				postDto.setImageList(Collections.emptyList()); // 빈 리스트로 설정
-					return postDto;
-				})
-				.toList();
-		}
+	public BoardDto toDto(BoardEntity boardEntity) {
+		List<PostDto> postList = postRepository.findAllByBoardIdOrderByIdDesc(boardEntity.getId())
+			.stream()
+			.map(postConverter::toDtoOnlyPost)
+			.toList();
+
 
 		return BoardDto.builder()
 			.id(boardEntity.getId())
@@ -45,6 +39,19 @@ public class BoardConverter {
 			.postList(postList)
 			.build();
 	}
+
+	public BoardDto toDtoOnlyBoard(BoardEntity boardEntity) {
+		return BoardDto.builder()
+			.id(boardEntity.getId())
+			.boardTitle(boardEntity.getBoardTitle())
+			.createdBy(boardEntity.getCreatedBy())
+			.createdAt(boardEntity.getCreatedAt())
+			.updatedBy(boardEntity.getUpdatedBy())
+			.updatedAt(boardEntity.getUpdatedAt())
+			.postList(List.of())
+			.build();
+	}
+
 
 	public BoardEntity toEntity(BoardDto boardDto) {
 		return BoardEntity.builder()

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardConverter.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardConverter.java
@@ -1,7 +1,10 @@
 package com.kernel360.orury.domain.board.service;
 
 import com.kernel360.orury.domain.board.db.BoardEntity;
+import com.kernel360.orury.domain.board.db.BoardRepository;
 import com.kernel360.orury.domain.board.model.BoardDto;
+import com.kernel360.orury.domain.post.db.PostEntity;
+import com.kernel360.orury.domain.post.db.PostRepository;
 import com.kernel360.orury.domain.post.model.PostDto;
 import com.kernel360.orury.domain.post.service.PostConverter;
 
@@ -10,22 +13,27 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class BoardConverter {
 
+	private final PostRepository postRepository;
 	private final PostConverter postConverter;
 
-	public BoardDto toDto(BoardEntity boardEntity) {
-		var postList = boardEntity.getPostList()
-			.stream()
-			.map(postEntity -> {
-				PostDto postDto = postConverter.toDto(postEntity);
+	public BoardDto toDto(BoardEntity boardEntity, boolean bool) {
+		List<PostDto> postList = List.of();
+		if (bool) {
+			postList = postRepository.findAllByBoardIdOrderByIdDesc(boardEntity.getId())
+				.stream()
+				.map(postEntity -> {
+					PostDto postDto = postConverter.toDto(postEntity, !bool);
 //				postDto.setImageList(Collections.emptyList()); // 빈 리스트로 설정
-				return postDto;
-			})
-			.toList();
+					return postDto;
+				})
+				.toList();
+		}
 
 		return BoardDto.builder()
 			.id(boardEntity.getId())

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
@@ -38,14 +38,14 @@ public class BoardService {
 
 		var saveEntity = boardRepository.save(entity);
 
-		return boardConverter.toDto(saveEntity);
+		return boardConverter.toDto(saveEntity, false);
 	}
 
 	// 게시판 조회
 	public List<BoardDto> getBoardList() {
 		List<BoardEntity> boardEntityList = boardRepository.findAll();
 		return boardEntityList.stream()
-			.map(boardConverter::toDto)
+			.map((BoardEntity boardEntity) -> boardConverter.toDto(boardEntity, false))
 			.toList();
 	}
 
@@ -56,7 +56,7 @@ public class BoardService {
 		BoardEntity entity = boardRepository.findById(boardRequest.getId())
 			.orElseThrow(() -> new BusinessException(BoardErrorCode.THERE_IS_NO_BOARD));
 
-		BoardDto updatedDto = boardConverter.toDto(entity);
+		BoardDto updatedDto = boardConverter.toDto(entity, false);
 		updatedDto.setBoardTitle(boardRequest.getBoardTitle());
 		updatedDto.setUpdatedBy(Constant.ADMIN.getMessage());
 		updatedDto.setUpdatedAt(LocalDateTime.now());
@@ -74,11 +74,11 @@ public class BoardService {
 		var entity = boardRepository.findById(id)
 			.orElseThrow(() -> new BusinessException(BoardErrorCode.THERE_IS_NO_BOARD));
 
-		return boardConverter.toDto(entity);
+		return boardConverter.toDto(entity, true);
 	}
 
 	public List<PostDto> getNoticeBoard(Long id) {
-		var noticeList = postRepository.findAllByBoardId(id);
+		var noticeList = postRepository.findAllByBoardIdOrderByIdDesc(id);
 		if(noticeList.isEmpty()) {
 			throw new BusinessException(BoardErrorCode.THERE_IS_NO_BOARD);
 		}

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/board/service/BoardService.java
@@ -38,14 +38,14 @@ public class BoardService {
 
 		var saveEntity = boardRepository.save(entity);
 
-		return boardConverter.toDto(saveEntity, false);
+		return boardConverter.toDtoOnlyBoard(saveEntity);
 	}
 
 	// 게시판 조회
 	public List<BoardDto> getBoardList() {
 		List<BoardEntity> boardEntityList = boardRepository.findAll();
 		return boardEntityList.stream()
-			.map((BoardEntity boardEntity) -> boardConverter.toDto(boardEntity, false))
+			.map(boardConverter::toDtoOnlyBoard)
 			.toList();
 	}
 
@@ -56,7 +56,7 @@ public class BoardService {
 		BoardEntity entity = boardRepository.findById(boardRequest.getId())
 			.orElseThrow(() -> new BusinessException(BoardErrorCode.THERE_IS_NO_BOARD));
 
-		BoardDto updatedDto = boardConverter.toDto(entity, false);
+		BoardDto updatedDto = boardConverter.toDtoOnlyBoard(entity);
 		updatedDto.setBoardTitle(boardRequest.getBoardTitle());
 		updatedDto.setUpdatedBy(Constant.ADMIN.getMessage());
 		updatedDto.setUpdatedAt(LocalDateTime.now());
@@ -74,7 +74,7 @@ public class BoardService {
 		var entity = boardRepository.findById(id)
 			.orElseThrow(() -> new BusinessException(BoardErrorCode.THERE_IS_NO_BOARD));
 
-		return boardConverter.toDto(entity, true);
+		return boardConverter.toDto(entity);
 	}
 
 	public List<PostDto> getNoticeBoard(Long id) {

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/comment/db/CommentEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/comment/db/CommentEntity.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -35,6 +37,7 @@ public class CommentEntity extends BaseEntity {
 
 	private Long userId;
 	@ManyToOne
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	@JsonIgnore
 	@ToString.Exclude
 	private PostEntity post;

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/comment/db/CommentRepository.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/comment/db/CommentRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<CommentEntity, Long>{
     // select * from comment where post_id = ?
-    List<CommentEntity> findAllByPostIdOrderByIdDesc(Long postId);
+    List<CommentEntity> findAllByPostId(Long postId);
 
     Long countByPostId(Long postId);
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/comment/db/CommentRepository.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/comment/db/CommentRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<CommentEntity, Long>{
     // select * from comment where post_id = ?
     List<CommentEntity> findAllByPostIdOrderByIdDesc(Long postId);
+
+    Long countByPostId(Long postId);
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/comment/service/CommentService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/comment/service/CommentService.java
@@ -104,12 +104,12 @@ public class CommentService {
         commentRepository.deleteById(commentId);
     }
 
-    public List<CommentDto> findAllByPostId(Long postId) {
-        List<CommentEntity> commentEntityList = commentRepository.findAllByPostIdOrderByIdDesc(postId);
-        return commentEntityList.stream()
-                .map(commentConverter::toDto)
-                .toList();
-    }
+//    public List<CommentDto> findAllByPostId(Long postId) {
+//        List<CommentEntity> commentEntityList = commentRepository.findAllByPostId(postId);
+//        return commentEntityList.stream()
+//                .map(commentConverter::toDto)
+//                .toList();
+//    }
 
     public boolean isWriter(String userEmail, Long id) {
         var comment = commentRepository.findById(id).orElseThrow(

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostEntity.java
@@ -41,8 +41,8 @@ public class PostEntity extends BaseEntity {
 	private int likeCnt;
 	private Long userId;
 
-	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-	@Builder.Default
-	@OrderBy(clause = "id asc")
-	private List<CommentEntity> commentList = List.of();
+//	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//	@Builder.Default
+//	@OrderBy(clause = "id asc")
+//	private List<CommentEntity> commentList = List.of();
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostEntity.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostEntity.java
@@ -7,6 +7,8 @@ import com.kernel360.orury.global.common.BaseEntity;
 import com.kernel360.orury.global.common.Listener;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.OrderBy;
 
 import javax.persistence.*;
@@ -26,6 +28,7 @@ public class PostEntity extends BaseEntity {
 	private Long id;
 
 	@ManyToOne
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	@JsonIgnore
 	@ToString.Exclude
 	private BoardEntity board;
@@ -41,8 +44,4 @@ public class PostEntity extends BaseEntity {
 	private int likeCnt;
 	private Long userId;
 
-//	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-//	@Builder.Default
-//	@OrderBy(clause = "id asc")
-//	private List<CommentEntity> commentList = List.of();
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostRepository.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostRepository.java
@@ -7,9 +7,5 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
-//    Optional<List<PostEntity>> findAllByBoardIdOrderByIdDesc(Long boardId);
-//    List<PostEntity> findAllByBoardIdOrderByIdDesc(Long boardId);
-
-//    @Query(value = "SELECT * FROM Post WHERE board_id = :boardId", nativeQuery = true)
     List<PostEntity> findAllByBoardIdOrderByIdDesc(Long boardId);
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostRepository.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/db/PostRepository.java
@@ -1,11 +1,15 @@
 package com.kernel360.orury.domain.post.db;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
-//    Optional<List<PostEntity>> findAllByBoardId(Long boardId);
-    List<PostEntity> findAllByBoardId(Long boardId);
+//    Optional<List<PostEntity>> findAllByBoardIdOrderByIdDesc(Long boardId);
+//    List<PostEntity> findAllByBoardIdOrderByIdDesc(Long boardId);
+
+//    @Query(value = "SELECT * FROM Post WHERE board_id = :boardId", nativeQuery = true)
+    List<PostEntity> findAllByBoardIdOrderByIdDesc(Long boardId);
 }

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/model/PostDto.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/model/PostDto.java
@@ -34,7 +34,7 @@ public class PostDto {
 	private String thumbnailUrl;
 	private List<String> imageList = List.of();
 	private Long commentCnt;
-	private List<CommentDto> commentList = List.of();
+//	private List<CommentDto> commentList = List.of();
 	private Map<String, List<CommentDto>> commentMap = Map.of();
 	@JsonProperty("is_like")
 	private boolean isLike;

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostService.java
@@ -57,14 +57,14 @@ public class PostService {
                 .build();
         var saveEntity = postRepository.save(entity);
 
-        return postConverter.toDto(saveEntity, false);
+        return postConverter.toDtoOnlyPost(saveEntity);
     }
 
     public PostDto getPost(Long id) {
         Optional<PostEntity> postEntityOptional = postRepository.findById(id);
         PostEntity post = postEntityOptional.orElseThrow(
                 () -> new BusinessException(PostErrorCode.THERE_IS_NO_POST));
-        return postConverter.toDto(post, true);
+        return postConverter.toDto(post);
     }
 
     public PostDto updatePost(
@@ -74,7 +74,7 @@ public class PostService {
         var postEntityOptional = postRepository.findById(postId);
         var entity = postEntityOptional.orElseThrow(
                 () -> new BusinessException(PostErrorCode.THERE_IS_NO_POST));
-        var dto = postConverter.toDto(entity, false);
+        var dto = postConverter.toDtoOnlyPost(entity);
         dto.setPostTitle(postRequest.getPostTitle());
         dto.setPostContent(postRequest.getPostContent());
         dto.setUpdatedBy(Constant.ADMIN.getMessage());
@@ -103,7 +103,7 @@ public class PostService {
                 .build();
 
         var dtoList = entityList.stream()
-                .map((PostEntity postEntity) -> postConverter.toDto(postEntity, false))
+                .map(postConverter::toDtoOnlyPost)
                 .toList();
 
         return Api.<List<PostDto>>builder()

--- a/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostService.java
+++ b/backend/orury/src/main/java/com/kernel360/orury/domain/post/service/PostService.java
@@ -57,14 +57,14 @@ public class PostService {
                 .build();
         var saveEntity = postRepository.save(entity);
 
-        return postConverter.toDto(saveEntity);
+        return postConverter.toDto(saveEntity, false);
     }
 
     public PostDto getPost(Long id) {
         Optional<PostEntity> postEntityOptional = postRepository.findById(id);
         PostEntity post = postEntityOptional.orElseThrow(
                 () -> new BusinessException(PostErrorCode.THERE_IS_NO_POST));
-        return postConverter.toDto(post);
+        return postConverter.toDto(post, true);
     }
 
     public PostDto updatePost(
@@ -74,7 +74,7 @@ public class PostService {
         var postEntityOptional = postRepository.findById(postId);
         var entity = postEntityOptional.orElseThrow(
                 () -> new BusinessException(PostErrorCode.THERE_IS_NO_POST));
-        var dto = postConverter.toDto(entity);
+        var dto = postConverter.toDto(entity, false);
         dto.setPostTitle(postRequest.getPostTitle());
         dto.setPostContent(postRequest.getPostContent());
         dto.setUpdatedBy(Constant.ADMIN.getMessage());
@@ -103,7 +103,7 @@ public class PostService {
                 .build();
 
         var dtoList = entityList.stream()
-                .map(postConverter::toDto)
+                .map((PostEntity postEntity) -> postConverter.toDto(postEntity, false))
                 .toList();
 
         return Api.<List<PostDto>>builder()

--- a/backend/orury/src/main/resources/application.yml
+++ b/backend/orury/src/main/resources/application.yml
@@ -25,11 +25,11 @@ spring:
           mode:NONE
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    #    url: ${LOCAL_DB_URL}    # configuration에서 설정 필요
+#    url: ${LOCAL_DB_URL}    # configuration에서 설정 필요
     url: ENC(4t9k8jNC5SIDd1hpsqRJiw5NgwtRAZ9l2cY42PcN3v6GNDC61KXk4X3nYwwUdW4+aC6g41zh14HyfWg+2fPmfuTXHg7aw+vTvL9Oomq1wEKM2r2ZHJbhmakdpmbeMVjVALC/MSk28Tp4a5sBhUFRWdpaFO2qQcpdUHUd9KsuJh0=)
-    #    username: ${LOCAL_DB_USERNAME}
+#    username: ${LOCAL_DB_USERNAME}
     username: ENC(2STroDy2TfWobkrTroFwbRcxLke05156ZFMrqwKmVssNcN4foSX4I6ax8YAgdW3R)
-    #    password: ${LOCAL_DB_USER_PASSWORD}
+#    password: ${LOCAL_DB_USER_PASSWORD}
     password: ENC(a8l7l/AYNz2x1HPYyu+urOBwVcBhQkeWgTi6Fvt+lQFq1QyHsL8yyi5+wr7lh26P)
   flyway:
     enabled: true
@@ -38,7 +38,7 @@ jwt:
   header: Authorization
   #HS512 알고리즘을 사용할 것이기 때문에 512bit, 즉 64byte 이상의 secret key를 사용해야 한다.
   #echo 'silvernine-tech-spring-boot-jwt-tutorial-secret-silvernine-tech-spring-boot-jwt-tutorial-secret'|base64
-  #  secret: ${LOCAL_JWT_SECRET_KEY}
+#  secret: ${LOCAL_JWT_SECRET_KEY}
   secret: ENC(XNkGVBeK1sJZhLhri+zz7pJOhHCvfif265mvT8OUIbOGeQcOCtHNnG2s3qjsKNe2u+dLoNVQBzbF1bKUfDxi8Po5tL7jQbZMPA33Dg1QMQFQWV46IyrYnLykYXQQvpin/SNPXW04ECDoRLF3TNwcS22D8uWEwe8L2wtcauyHeO1z+J6lUQArPHy76O2pzC7FHlBjOTw3STd23e3dd1WBQtHAYVmOIvNuPreulzSaHXc=)
   access-validity: 1800
   refresh-validity: 7200

--- a/frontend/lib/presentation/Board/post_create.dart
+++ b/frontend/lib/presentation/Board/post_create.dart
@@ -141,6 +141,7 @@ class _PostCreateState extends State<PostCreate> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        centerTitle: true,
         title: Text('게시글 작성'),
       ),
       body: Padding(

--- a/frontend/lib/presentation/Board/post_detail.dart
+++ b/frontend/lib/presentation/Board/post_detail.dart
@@ -255,6 +255,7 @@ class _PostDetailState extends State<PostDetail> {
 
           return Scaffold(
             appBar: AppBar(
+              centerTitle: true,
               title: Text('게시물 상세보기'),
             ),
             body: Padding(
@@ -322,7 +323,31 @@ class _PostDetailState extends State<PostDetail> {
                                         );
                                       } else if (result == 'delete') {
                                         // 게시글 삭제 기능 구현
-                                        deletePost();
+                                        showDialog(
+                                          context: context,
+                                          builder: (BuildContext context) {
+                                            return AlertDialog(
+                                              title: Text('삭제 확인'),
+                                              content: Text('내용을 삭제하시겠습니까?'),
+                                              actions: <Widget>[
+                                                TextButton(
+                                                  child: Text('취소'),
+                                                  onPressed: () {
+                                                    router.pop();  // Dialog를 닫습니다.
+                                                  },
+                                                ),
+                                                TextButton(
+                                                  child: Text('삭제'),
+                                                  onPressed: () {
+                                                    // 여기에 삭제 관련 코드를 작성합니다.
+                                                    deletePost();
+                                                    router.pop();  // Dialog를 닫습니다.
+                                                  },
+                                                ),
+                                              ],
+                                            );
+                                          },
+                                        );
                                       }
                                     },
                                     itemBuilder: (BuildContext context) =>

--- a/frontend/lib/presentation/main/main_screen.dart
+++ b/frontend/lib/presentation/main/main_screen.dart
@@ -37,7 +37,7 @@ class _MainScreenState extends State<MainScreen> {
     super.initState();
     initSharedPreferences();
     connectToServer();
-    loadBoards();
+    // loadBoards();
   }
 
   @override
@@ -81,10 +81,11 @@ class _MainScreenState extends State<MainScreen> {
       // Uri.http(dotenv.env['API_URL']!, '/api/board'),
       Uri.http(dotenv.env['AWS_API_URL']!, '/api/board'),
     );
-
+    print('함수명 : getBoards');
     final jsonData = jsonDecode(utf8.decode(response.bodyBytes)) as List;
     final boards =
         jsonData.map((boardJson) => Boards.fromJson(boardJson)).toList();
+    print(boards[0].boardTitle);
     return boards;
   }
 
@@ -100,7 +101,7 @@ class _MainScreenState extends State<MainScreen> {
       // Uri.http(dotenv.env['API_URL']!, '/api/board/1'),
       Uri.http(dotenv.env['AWS_API_URL']!, '/api/board/$boardId'),
     );
-
+    print('함수명 : fetchPosts');
     final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
     final board = Board.fromJson(jsonData);
     return board.postList;


### PR DESCRIPTION
## 개요
게시글 목록 화면에서 api 응답을 받는데 오래 걸려서 원인으로 예상되는 쿼리쪽 오버헤드를 줄이기 위한 코드 리팩토링

### 상세 내용
- 최대한 필요한 데이터만 db에서 꺼내서 api 응답으로 보낼 수 있게 코드를 수정하여 기존의 오버헤드 비용을 줄임
- 엔티티는 OneToMany는 제거하고 ManyToOne은 그대로 유지
- post_list나 comment_list는 필요할 때 jpa 쿼리로 꺼내오는 형식으로 변경
- 프런트엔드 보충

### 중요
- DB 초기화 하셔야 상위 엔티티의 삭제가 잘됩니다.

Resolves: #181 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://quickest-asterisk-75d.notion.site/2a977a0d71db4062bc705dc199ebff13?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
